### PR TITLE
Add Elasticsearch to chart, refactor backend configuration values

### DIFF
--- a/signals-backend/Chart.lock
+++ b/signals-backend/Chart.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: rabbitmq
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 6.14.2
-digest: sha256:5418681fd045ebda355ded9b6a1baa5816f0d16861e37b57d2a35c1d266e9809
-generated: "2019-12-18T14:12:18.068863+01:00"
+- name: elasticsearch
+  repository: https://helm.elastic.co
+  version: ~6.8.0
+digest: sha256:f985dfeda6f14bba366ea2e4877c2481e960d68d5ba3d542d056af2695444f58
+generated: "2020-06-25T09:41:24.176349+02:00"

--- a/signals-backend/Chart.yaml
+++ b/signals-backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: signals-backend
 description: The API for the Signals application
 type: application
-version: 0.1.0
+version: 0.2.0
 
 dependencies:
   - name: postgresql
@@ -15,3 +15,8 @@ dependencies:
     repository: https://kubernetes-charts.storage.googleapis.com
     tags:
       - rabbitmq
+  - name: elasticsearch
+    version: ~6.8.0
+    repository: https://helm.elastic.co
+    tags:
+      - elasticsearch

--- a/signals-backend/templates/deployment-celery-beat.yaml
+++ b/signals-backend/templates/deployment-celery-beat.yaml
@@ -34,29 +34,27 @@ spec:
                 secretKeyRef:
                   name: {{ template "signals-backend.fullname" . }}
                   key: secret-key
-
             - name: DATABASE_HOST_OVERRIDE
-              value: {{ .Values.database.hostname }}
+              value: {{ .Values.settings.database.host }}
             - name: DATABASE_PORT_OVERRIDE
-              value: "5432"
-            - name: DATABASE_NAME
-              value: {{ .Values.database.databaseName }}
+              value: {{ .Values.settings.database.port | quote }}
             - name: DATABASE_USER
-              value: {{ .Values.database.username }}
+              value: {{ .Values.settings.database.username }}
             - name: DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "signals-backend.fullname" . }}
                   key: database-password
-
+            - name: DATABASE_NAME
+              value: {{ .Values.settings.database.name }}
             - name: RABBITMQ_HOST
-              value: {{ .Values.celery.rabbitmq.hostname }}
-            - name: RABBITMQ_VHOST
-              value: ""
+              value: {{ .Values.settings.rabbitmq.host }}
             - name: RABBITMQ_USER
-              value: {{ .Values.celery.rabbitmq.username }}
+              value: {{ .Values.settings.rabbitmq.username }}
             - name: RABBITMQ_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "signals-backend.fullname" . }}
                   key: rabbitmq-password
+            - name: RABBITMQ_VHOST
+              value: {{ .Values.settings.rabbitmq.vhost }}

--- a/signals-backend/templates/deployment-celery-worker.yaml
+++ b/signals-backend/templates/deployment-celery-worker.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "signals-backend.labels" . | nindent 4 }}
     component: cellery-worker
 spec:
-  replicas: {{ .Values.celery.worker.replicaCount }}
+  replicas: {{ .Values.workerReplicaCount }}
   revisionHistoryLimit: 2
   selector:
     matchLabels:
@@ -34,59 +34,54 @@ spec:
                 secretKeyRef:
                   name: {{ template "signals-backend.fullname" . }}
                   key: secret-key
-
             - name: DATABASE_HOST_OVERRIDE
-              value: {{ .Values.database.hostname }}
+              value: {{ .Values.settings.database.host }}
             - name: DATABASE_PORT_OVERRIDE
-              value: "5432"
-            - name: DATABASE_NAME
-              value: {{ .Values.database.databaseName }}
+              value: {{ .Values.settings.database.port | quote }}
             - name: DATABASE_USER
-              value: {{ .Values.database.username }}
+              value: {{ .Values.settings.database.username }}
             - name: DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "signals-backend.fullname" . }}
                   key: database-password
-
+            - name: DATABASE_NAME
+              value: {{ .Values.settings.database.name }}
             - name: RABBITMQ_HOST
-              value: {{ .Values.celery.rabbitmq.hostname }}
-            - name: RABBITMQ_VHOST
-              value: ""
+              value: {{ .Values.settings.rabbitmq.host }}
             - name: RABBITMQ_USER
-              value: {{ .Values.celery.rabbitmq.username }}
+              value: {{ .Values.settings.rabbitmq.username }}
             - name: RABBITMQ_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "signals-backend.fullname" . }}
                   key: rabbitmq-password
-
+            - name: RABBITMQ_VHOST
+              value: {{ .Values.settings.rabbitmq.vhost }}
             - name: EMAIL_HOST
-              value: {{ .Values.smtp.hostname }}
+              value: {{ .Values.settings.email.hostname }}
             - name: EMAIL_PORT
-              value: {{ .Values.smtp.port | quote }}
+              value: {{ .Values.settings.email.port | quote }}
             - name: EMAIL_HOST_USER
-              value: {{ .Values.smtp.username }}
+              value: {{ .Values.settings.email.username }}
             - name: EMAIL_HOST_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "signals-backend.fullname" . }}
-                  key: smtp-password
+                  key: email-password
             - name: EMAIL_USE_TLS
-              value: {{ .Values.smtp.useTLS | quote }}
+              value: {{ .Values.settings.email.useTLS | quote }}
             - name: EMAIL_USE_SSL
-              value: {{ .Values.smtp.useSSL | quote }}
-
+              value: {{ .Values.settings.email.useSSL | quote }}
             - name: EMAIL_FLEX_HORECA_INTEGRATION_ADDRESS
-              value: {{ .Values.emailAddresses.flexHoreca }}
+              value: {{ .Values.settings.emailAddresses.flexHoreca }}
             - name: EMAIL_TOEZICHT_OR_NIEUW_WEST_INTEGRATION_ADDRESS
-              value: {{ .Values.emailAddresses.toezichtNieuwWest }}
+              value: {{ .Values.settings.emailAddresses.toezichtNieuwWest }}
             - name: EMAIL_VTH_NIEUW_WEST_INTEGRATION_ADDRESS
-              value: {{ .Values.emailAddresses.vthNieuwWest }}
-
-            {{- if .Values.sigmax.enabled }}
+              value: {{ .Values.settings.emailAddresses.vthNieuwWest }}
+            {{- if .Values.settings.sigmax.enabled }}
             - name: SIGMAX_SERVER
-              value: {{ .Values.sigmax.serverUrl }}
+              value: {{ .Values.settings.sigmax.serverUrl }}
             - name: SIGMAX_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/signals-backend/templates/deployment.yaml
+++ b/signals-backend/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
               containerPort: 8080
           env:
             - name: ALLOWED_HOSTS
-              value: {{ .Values.allowedHosts | quote }}
+              value: {{ .Values.settings.allowedHosts | quote }}
             - name: DJANGO_LOG_LEVEL
               value: error
             - name: DJANGO_SETTINGS_MODULE
@@ -75,33 +75,37 @@ spec:
                   name: {{ template "signals-backend.fullname" . }}
                   key: secret-key
             - name: DATAPUNT_API_URL
-              value: {{ .Values.datapuntApiUrl }}
+              value: {{ .Values.settings.datapuntApiUrl }}
             - name: DWH_MEDIA_ROOT
               value: /dwh_media
             - name: DATABASE_HOST_OVERRIDE
-              value: {{ .Values.database.hostname }}
+              value: {{ .Values.settings.database.host }}
             - name: DATABASE_PORT_OVERRIDE
-              value: "5432"
-            - name: DATABASE_NAME
-              value: {{ .Values.database.databaseName }}
+              value: {{ .Values.settings.database.port | quote }}
             - name: DATABASE_USER
-              value: {{ .Values.database.username }}
+              value: {{ .Values.settings.database.username }}
             - name: DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "signals-backend.fullname" . }}
                   key: database-password
+            - name: DATABASE_NAME
+              value: {{ .Values.settings.database.name }}
             - name: RABBITMQ_HOST
-              value: {{ .Values.celery.rabbitmq.hostname }}
-            - name: RABBITMQ_VHOST
-              value: ""
+              value: {{ .Values.settings.rabbitmq.host }}
             - name: RABBITMQ_USER
-              value: {{ .Values.rabbitmq.rabbitmq.username }}
+              value: {{ .Values.settings.rabbitmq.username }}
             - name: RABBITMQ_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "signals-backend.fullname" . }}
                   key: rabbitmq-password
+            - name: RABBITMQ_VHOST
+              value: {{ .Values.settings.rabbitmq.vhost }}
+            - name: ELASTICSEARCH_HOST
+              value: {{ .Values.settings.elasticsearch.host }}
+            - name: ELASTICSEARCH_INDEX
+              value: {{ .Values.settings.elasticsearch.index }}
           volumeMounts:
             - name: media
               mountPath: /media/attachments

--- a/signals-backend/templates/ingress.yaml
+++ b/signals-backend/templates/ingress.yaml
@@ -4,12 +4,10 @@ metadata:
   name: {{ template "signals-backend.fullname" . }}
   labels:
     {{- include "signals-backend.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
-    ingress.kubernetes.io/hsts-include-subdomains: "true"
-    ingress.kubernetes.io/hsts-max-age: "315360000"
-    ingress.kubernetes.io/hsts-preload: "true"
-    ingress.kubernetes.io/ssl-redirect: "true"
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   rules:
     - host: {{ .Values.ingress.host }}

--- a/signals-backend/templates/job-migrate.yaml
+++ b/signals-backend/templates/job-migrate.yaml
@@ -23,15 +23,15 @@ spec:
                   name: {{ template "signals-backend.fullname" . }}
                   key: secret-key
             - name: DATABASE_HOST_OVERRIDE
-              value: {{ .Values.database.hostname }}
+              value: {{ .Values.settings.database.host }}
             - name: DATABASE_PORT_OVERRIDE
-              value: "5432"
-            - name: DATABASE_NAME
-              value: {{ .Values.database.databaseName }}
+              value: {{ .Values.settings.database.port | quote }}
             - name: DATABASE_USER
-              value: {{ .Values.database.username }}
+              value: {{ .Values.settings.database.username }}
             - name: DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "signals-backend.fullname" . }}
                   key: database-password
+            - name: DATABASE_NAME
+              value: {{ .Values.settings.database.name }}

--- a/signals-backend/templates/secret.yaml
+++ b/signals-backend/templates/secret.yaml
@@ -7,10 +7,10 @@ metadata:
 type: Opaque
 data:
   secret-key: {{ randAlphaNum 10 | b64enc }}
-  database-password: {{ .Values.database.password | b64enc }}
-  rabbitmq-password: {{ .Values.celery.rabbitmq.password | b64enc }}
-  smtp-password: {{ .Values.smtp.password | quote | b64enc }}
-{{- if .Values.sigmax.enabled }}
+  database-password: {{ .Values.settings.database.password | b64enc }}
+  rabbitmq-password: {{ .Values.settings.rabbitmq.password | b64enc }}
+  email-password: {{ .Values.settings.email.password | quote | b64enc }}
+{{- if .Values.settings.sigmax.enabled }}
 ---
 apiVersion: v1
 kind: Secret
@@ -20,5 +20,5 @@ metadata:
     {{- include "signals-backend.labels" . | nindent 4 }}
 type: Opaque
 data:
-  auth-token: {{ .Values.sigmax.authToken | b64enc }}
+  auth-token: {{ .Values.settings.sigmax.authToken | b64enc }}
 {{- end }}

--- a/signals-backend/values.yaml
+++ b/signals-backend/values.yaml
@@ -1,9 +1,11 @@
 tags:
   postgresql: true
   rabbitmq: true
+  elasticsearch: true
 
-allowedHosts: "*"
 replicaCount: 1
+workerReplicaCount: 1
+
 deploymentStrategy: Recreate
 
 image:
@@ -16,63 +18,57 @@ service:
   port: 80
 
 ingress:
-  class: traefik
   host: api.signals.local
+  annotations:
+    ingress.kubernetes.io/hsts-include-subdomains: "true"
+    ingress.kubernetes.io/hsts-max-age: "315360000"
+    ingress.kubernetes.io/hsts-preload: "true"
+    ingress.kubernetes.io/ssl-redirect: "true"
 
 persistence:
   enabled: true
   size: 1Gi
   existingClaim: null
 
-database:
-  hostname: signals-backend-postgresql
-  databaseName: signals
-  username: signals
-  password: signals
+settings:
+  allowedHosts: "*"
 
-celery:
-  worker:
-    replicaCount: 1
-  rabbitmq:
-    hostname: signals-backend-rabbitmq
+  database:
+    host: signals-backend-postgresql
+    port: 5432
     username: signals
     password: signals
-
-smtp:
-  hostname: mailhog
-  port: 25
-  username: ""
-  password: ""
-  useTLS: false
-  useSSL: false
-
-datapuntApiUrl: https://api.data.amsterdam.nl/
-
-emailAddresses:
-  flexHoreca: flex-horeca@signals.local
-  toezichtNieuwWest: toezicht-nieuw-west@signals.local
-  vthNieuwWest: vth-nieuw-west@signals.local
-
-sigmax:
-  enabled: false
-  serverUrl: http://sigmax.sigmax
-  authToken: insecure
-
-#######################
-## RabbitMQ subchart ##
-#######################
-rabbitmq:
-  image:
-    tag: "3.8"
+    name: signals
 
   rabbitmq:
+    host: signals-backend-rabbitmq
     username: signals
     password: signals
+    vhost: ""
 
-  persistence:
-    enabled: true
-    size: 1Gi
-    existingClaim: null
+  elasticsearch:
+    host: elasticsearch
+    index: signals
+
+  email:
+    hostname: mailhog
+    port: 25
+    username: ""
+    password: ""
+    useTLS: false
+    useSSL: false
+
+  datapuntApiUrl: https://api.data.amsterdam.nl/
+
+  emailAddresses:
+    flexHoreca: flex-horeca@signals.local
+    toezichtNieuwWest: toezicht-nieuw-west@signals.local
+    vthNieuwWest: vth-nieuw-west@signals.local
+
+  sigmax:
+    enabled: false
+    serverUrl: http://sigmax.sigmax
+    authToken: insecure
 
 #########################
 ## PostgreSQL subchart ##
@@ -90,3 +86,36 @@ postgresql:
   postgresqlDatabase: signals
   postgresqlUsername: signals
   postgresqlPassword: signals
+
+#######################
+## RabbitMQ subchart ##
+#######################
+rabbitmq:
+  image:
+    tag: "3.8"
+
+  rabbitmq:
+    username: signals
+    password: signals
+
+  persistence:
+    enabled: true
+    size: 1Gi
+    existingClaim: null
+
+############################
+## Elasticsearch subchart ##
+############################
+elasticsearch:
+  replicas: 1
+  minimumMasterNodes: 1
+
+  esJavaOpts: "-Xmx512m -Xms512m"
+
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "1Gi"
+    limits:
+      cpu: "500m"
+      memory: "1Gi"


### PR DESCRIPTION
- Add Elasticsearch as subchart to the backend.
- Refactor configuration values. All application-specific settings are now grouped under the settings key.

Fixes https://github.com/Signalen/backend/issues/36
Depends on https://github.com/Amsterdam/signals/pull/531