### PR TITLE
Improve documentation on Helm charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,107 @@
 # Signalen Helm charts
 
-[Signalen](https://signalen.org/) helps cities receive, manage and solve nuisance reports. The software is open source and therefore free for others to use. This repository contains [Helm charts](https://helm.sh/) to easily install the software.
+[Signalen](https://signalen.org/) helps cities receive, manage and solve nuisance reports. The software is open source and therefore free for others to use. This repository contains [Helm charts](https://helm.sh/) to easily install the Signalen stack on a Kubernetes cluster.
+
+## External authentication
+
+The Signalen backoffice relies on an external OpenID Connect identity provider for authentication of users. If no instance is available, [Dex](https://github.com/dexidp/dex) could be used with a static user as follows:
+
+```bash
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm upgrade --install \
+  dex stable/dex \
+  --create-namespace \
+  --namespace dex \
+  --set "config.issuer=https://dex.signalen.example.com" \
+  --set "config.staticPasswords[0].email=signals.admin@example.com" \
+  --set "config.staticPasswords[0].hash=$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W" \
+  --set "config.staticPasswords[0].username=admin" \
+  --set "config.staticClients[0].id=signals" \
+  --set "config.staticClients[0].name=Signalen" \
+  --set "config.staticClients[0].secret=somethingsecret" \
+  --set "config.staticClients[0].redirectURIs[0]=https://signalen.example.com/manage/incidents" \
+  --set "config.oauth2.responseTypes={token,id_token}" \
+  --set "ingress.enabled=true" \
+  --set "ingress.hosts[0]=dex.signalen.example.com"
+```
+
+This command will install Dex in the dex namespace and exposes an [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) on dex.signalen.example.com. It creates the following static user:
+
+- E-mail: signalen.admin@example.com
+- Password: password
+
+Dex has a lot of benefits when connected to an Identity Provider [using connectors](https://github.com/dexidp/dex#connectors). It provides out-of-the box support for LDAP, SAML2.0, GitHub, GitLab and more.
 
 ## Install the charts
 
-First create the namespace `signals` and initialize the backend chart:
+First clone this repository with the Helm charts and initialize the backend chart:
 
-```console
-$ kubectl create namespace signals
-$ (cd backend/ && helm dependency update)
+```bash
+git clone https://github.com/Signalen/helm-charts.git
+(cd backend/ && helm dependency update)
 ```
 
-Then install the charts:
+Then install the backend chart:
 
-```console
-$ helm upgrade --install -n signals frontend ./frontend
-$ helm upgrade --install -n signals backend ./backend
-$ helm upgrade --install -n signals classification ./classification
+```bash
+helm upgrade --install \
+  signals-backend ./backend \
+  --create-namespace \
+  --namespace signals \
+  --set "settings.allowedHosts=api.signals.example.com" \
+  --set "settings.defaultPdokMunicipalities=Amsterdam" \
+  --set "settings.jwksUrl=https://dex.signals.example.com" \
+  --set "settings.userIdField=email" \
+  --set "settings.classificationEndpoint=https://classification.signals.example.com/signals_mltool" \
+  --set "ingress.enabled=true" \
+  --set "ingress.host=api.signals.example.com"
 ```
 
-## Delete the charts
+And install the frontend chart:
+
+```bash
+helm upgrade --install \
+  signals-frontend ./frontend \
+  --create-namespace \
+  --namespace signals \
+  --set "oidc.authEndpoint=https://dex.signals.example.com/auth" \
+  --set "config.apiBaseUrl=https://api.signals.example.com/signals" \
+  --set "ingress.enabled=true" \
+  --set "ingress.host=signals.example.com"
+```
+
+And install the classification chart with:
+
+```bash
+helm upgrade --install \
+  signals-classification ./classification \
+  --create-namespace \
+  --namespace signals \
+  --set "signalsCategoryUrl=https://api.signals.example.com/signals/v1/public/terms" \
+  --set "ingress.enabled=true" \
+  --set "ingress.host=classification.signals.example.com"
+```
+
+## Uninstall the charts
 
 To delete the charts:
 
-```console
-$ helm delete -n signals frontend
-$ helm delete -n signals backend
-$ helm delete -n signals classification
+```bash
+helm delete --namespace signals signals-frontend
+helm delete --namespace signals signals-backend
+helm delete --namespace signals signals-classification
 ```
 
 And finally remove the namespace:
 
-```console
-$ kubectl delete namespace signals
+```bash
+kubectl delete namespace signals
 ```
+
+## Configuration
+
+Consult the documentation of the specific charts for an overview of all configuration options:
+
+- [backend](./backend)
+- [frontend](./frontend)
+- [classification](./classification)

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,36 @@
+# Signalen backend Helm chart
+
+The backend Helm chart installs the Signalen API and the by default the following dependencies using subcharts:
+
+- PostgreSQL
+- RabbitMQ
+- Elasticsearch
+
+## Configuration
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `tags.postgresql` | Install PostgreSQL subchart | `true` |
+| `tags.rabbitmq` | Install RabbitMQ subchart | `true` |
+| `tags.elasticsearch` | Install Elasticsearch subchart | `true` |
+| `image.repository` | The repository of the Docker image | `signalen/frontend` |
+| `image.tag` | The tag of the Docker image | `latest` |
+| `replicaCount` | The number of API replicas | `1` |
+| `workerReplicaCount` | The number of background worker replicas | `1` |
+| `settings.allowedHosts` | Restrict the allowed hosts of the API | `*` |
+| `settings.defaultPdokMunicipalities` | A (comma-seperated) list of [PDOK municipalities](https://www.pdok.nl/introductie/-/article/cbs-wijken-en-buurten) the API allows complaints for (e.g. `"Amsterdam,'s-Hertogenbosch"`) | `""` |
+| `settings.jwksUrl` | The JWKS url of the OpenID Connect Identity Provider | `""` |
+| `settings.userIdField` | The JWKS url of the OpenID Connect Identity Provider | `""` |
+| `settings.email.hostname` | The hostname of the SMTP server for e-mail notifications | `""` |
+| `settings.email.port` | The port of the SMTP server | `""` |
+| `settings.email.useTLS` | Use TLS while connecting to the SMTP server | `false` |
+| `settings.email.useSSL` | Use SSL while connecting to the SMTP server | `false` |
+| `settings.classificationService` | Use SSL while connecting to the SMTP server | `https://api.data.amsterdam.nl/signals_mltool` |
+| `sigmax.enabled` | Enable the connection with Sigmax City Control | `false` |
+| `sigmax.serverUrl` | The server URL of Sigmax | `` |
+| `sigmax.authToken` | The token to authenticate with Sigmax | `` |
+| `ingress.enabled` | Expose the API through an ingress | `true` |
+| `ingress.annotations` | Additional annotations on the API ingress | `{}` |
+| `ingress.host` | The host of the API | `""` |
+
+Check [values.yaml](./values.yaml) for all the possible configuration options.

--- a/backend/templates/deployment.yaml
+++ b/backend/templates/deployment.yaml
@@ -90,7 +90,7 @@ spec:
             - name: USER_ID_FIELD
               value: {{ .Values.settings.userIdField }}
             - name: SIGNALS_ML_TOOL_ENDPOINT
-              value: {{ .Values.settings.classificationService }}
+              value: {{ .Values.settings.classificationEndpoint }}
           volumeMounts:
             - name: media
               mountPath: /media

--- a/backend/values.yaml
+++ b/backend/values.yaml
@@ -70,7 +70,7 @@ settings:
 
   datapuntApiUrl: https://api.data.amsterdam.nl/
 
-  classificationService: https://api.data.amsterdam.nl/signals_mltool
+  classificationEndpoint: https://api.data.amsterdam.nl/signals_mltool
 
   emailAddresses:
     flexHoreca: flex-horeca@signals.local

--- a/classification/README.md
+++ b/classification/README.md
@@ -1,0 +1,19 @@
+# Signalen classification Helm chart
+
+This Helm chart contains the Signalen classification service. It automatically classifies nuisance reports using machine learning.
+
+The classification service expects a trained machine learning model in the folder `/models` on the persistent volume. For more information how to train a model see [the documentation](https://github.com/Signalen/classification/blob/master/README.md).
+
+## Configuration
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `image.repository` | The repository of the Docker image | `signalen/frontend` |
+| `image.tag` | The tag of the Docker image | `latest` |
+| `signalsCategoryUrl` | This prefix that will be added to every category slug | `http://api.signals.example.com/signals/v1/public/terms` |
+| `replicaCount` | The number of API replicas | `1` |
+| `ingress.enabled` | Expose the API through an ingress | `true` |
+| `ingress.annotations` | Additional annotations on the API ingress | `{}` |
+| `ingress.host` | The host of the API | `""` |
+
+Check [values.yaml](./values.yaml) for all the possible configuration options.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,17 @@
+# Signalen frontend Helm chart
+
+This Helm chart contains the Signalen web frontend.
+
+## Configuration
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `image.repository` | The repository of the Docker image | `signalen/frontend` |
+| `image.tag` | The tag of the Docker image | `latest` |
+| `replicaCount` | The number of API replicas | `1` |
+| `config` | The configuration of the frontend. For all options see [environment.conf.json](https://github.com/Signalen/frontend/blob/develop/environment.conf.json) | `{}` |
+| `ingress.enabled` | Expose the API through an ingress | `true` |
+| `ingress.annotations` | Additional annotations on the API ingress | `{}` |
+| `ingress.host` | The host of the API | `""` |
+
+Check [values.yaml](./values.yaml) for all the possible configuration options.

--- a/frontend/templates/configmap.yaml
+++ b/frontend/templates/configmap.yaml
@@ -5,4 +5,5 @@ metadata:
   labels:
     {{- include "signals-frontend.labels" . | nindent 4 }}
 data:
-  environment.conf.json: {{ .Values.config | toJson | quote }}
+  environment.conf.json: |-
+    {{ .Values.config | toJson | nindent 4 }}

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -24,53 +24,76 @@ ingress:
         - frontend.signals.local
 
 config:
+  apiBaseUrl: https://api.signals.local/signals
+  mapsBaseUrl: https://map.data.amsterdam.nl/maps
+  oidc:
+    clientId: signals
+    authEndpoint: https://dex.signals.local/auth
+    responseType: id_token
+    scope: "openid email profile"
+  head:
+    androidIcon: "/icon_192x192.png"
+    backgroundColor: "#ffffff"
+    favicon: "/favicon.png"
+    iosIcon: "/icon_180x180.png"
+    statusBarStyle: "default"
+    themeColor: "#ec0000"
+  logo:
+    url: null
+    width: 0
+    height: 0
+    smallWidth: 0
+    smallHeight: 0
   logoUrl: null
   logoHeight: 0
-  sentry: null
-  matamo: null
+  sentry:
+    dsn: ""
+  matamo:
+    urlBase: ""
+    siteId: 0
   language:
-    footer1: "Hier komt een informatietekst"
-    footer2: "die je zelf kan configureren."
+    avgDisclaimer: "De gemeente Amsterdam verwerkt uw persoonsgegevens op een zorgvuldige en veilige manier in overeenstemming met de geldende wet- en regelgeving, waaronder de Algemene Verordening Gegevensbescherming. Lees meer hierover op <a href='##AVG_DISCLAIMER_URL##'>Privacyverklaring Meldingen openbare ruimte en overlast</a>."
+    consentToContactSharing: "Ja, ik geef de gemeente Amsterdam toestemming om mijn contactgegevens te delen met andere organisaties, als dat nodig is om mijn melding goed op te lossen."
+    footer1: "Bel het Gemeentelijk informatienummer: 000000"
+    footer2: "op werkdagen van 08.00 tot 18.00 uur."
+    headerTitle: ""
+    phoneNumber: "14 020"
+    shortTitle: "SIA"
+    siteTitle: "SIA - Signalen Informatievoorziening Amsterdam"
+    smallHeaderTitle: "SIA"
+    title: "Signalen Informatievoorziening Amsterdam"
+    urgentContactInfo: "Voor spoedeisende zaken kunt u ook telefonisch contact opnemen met 14 020."
   links:
-    home: https://frontend.signals.local
-    privacy: https://privacy.signals.local
-  theme: {}
+    help: "https://tamtam.amsterdam.nl/do/office?id=1723860-6f6666696365"
+    home: "https://www.amsterdam.nl"
+    privacy: "https://www.amsterdam.nl/privacy/specifieke/privacyverklaringen-wonen/meldingen-overlast-privacy/"
+  theme:
+    primary:
+      main: "#004699"
+      dark: "#00387a"
+    secondary:
+      main: "#ec0000"
+      dark: "#bc0000"
+    support:
+      valid: "#00A03C"
+      invalid: "#EC0000"
+      focus: "#FEC813"
+    error:
+      main: "#ec0000"
   map:
-    tiles:
-      args:
-        - "https://{s}.data.amsterdam.nl/topo_rd/{z}/{x}/{y}.png"
-      options:
-        subdomains: ["t1", "t2", "t3", "t4"]
-        tms: true
-        attribution: "Kaartgegevens CC-BY-4.0 Gemeente Amsterdam"
+    municipality: "Amsterdam"
     options:
       maxBounds:
         - [52.25168, 4.64034]
         - [52.50536, 5.10737]
       center: [52.3731081, 4.8932945]
       zoom: 10
-  ROOT: https://api.signals.local/
-  AUTH_ROOT: https://auth.signals.local/
-  API_ROOT_MAPSERVER: https://map.data.amsterdam.nl/
-  USERS_ENDPOINT: https://api.signals.local/signals/v1/private/users/
-  ROLES_ENDPOINT: https://api.signals.local/signals/v1/private/roles/
-  PERMISSIONS_ENDPOINT: https://api.signals.local/signals/v1/private/permissions/
-  SEARCH_ENDPOINT: https://api.signals.local/signals/v1/private/search
-  PREDICTION_ENDPOINT: https://api.signals.local/signals/category/prediction
-  INCIDENT_PUBLIC_ENDPOINT: https://api.signals.local/signals/v1/public/signals/
-  INCIDENT_PRIVATE_ENDPOINT: https://api.signals.local/signals/v1/private/signals/
-  INCIDENTS_ENDPOINT: https://api.signals.local/signals/v1/private/signals/
-  GEOGRAPHY_ENDPOINT: https://api.signals.local/signals/v1/private/signals/geography
-  PRIORITY_ENDPOINT: https://api.signals.local/signals/auth/priority/
-  FEEDBACK_STANDARD_ANSWERS_ENDPOINT: https://api.signals.local/signals/v1/public/feedback/standard_answers/
-  FEEDBACK_FORMS_ENDPOINT: https://api.signals.local/signals/v1/public/feedback/forms/
-  AUTH_ME_ENDPOINT: https://api.signals.local/signals/v1/private/me/
-  CATEGORIES_PRIVATE_ENDPOINT: https://api.signals.local/signals/v1/private/categories/
-  CATEGORIES_ENDPOINT: https://api.signals.local/signals/v1/public/terms/categories/
-  TERMS_ENDPOINT: https://api.signals.local/signals/v1/private/terms/categories/
-  IMAGE_ENDPOINT: https://api.signals.local/signals/signal/image/
-  FILTERS_ENDPOINT: https://api.signals.local/signals/v1/private/me/filters/
-  DEPARTMENTS_ENDPOINT: https://api.signals.local/signals/v1/private/departments/
-  DASHBOARD_ENDPOINT: https://api.signals.local/signals/experimental/dashboards/1
-  OVL_KLOKKEN_LAYER: https://map.data.amsterdam.nl/maps/openbare_verlichting?REQUEST=GetFeature&SERVICE=wfs&OUTPUTFORMAT=application/json;%20subtype=geojson;%20charset=utf-8&Typename=Klokken&version=1.1.0&srsname=urn:ogc:def:crs:EPSG::4326
-  OVL_VERLICHTING_LAYER: https://map.data.amsterdam.nl/maps/openbare_verlichting?REQUEST=GetFeature&SERVICE=wfs&OUTPUTFORMAT=application/json;%20subtype=geojson;%20charset=utf-8&Typename=Verlichting&version=1.1.0&srsname=urn:ogc:def:crs:EPSG::4326
+    tiles:
+      args:
+        - "https://{s}.data.amsterdam.nl/topo_rd/{z}/{x}/{y}.png"
+      options:
+        attribution: "Kaartgegevens CC-BY-4.0 Gemeente Amsterdam"
+        subdomains: ["t1", "t2", "t3", "t4"]
+        tms: true
+  fetchQuestionsFromBackend: true
+  showVulaanControls: true


### PR DESCRIPTION
This PR improves documentation on installing the Helm charts and specific configuration options of the charts.

Depends on Signalen/frontend#71.
Closes Signalen/backend#60.