### PR TITLE
Standardize ingress for classification

### DIFF
--- a/classification/templates/ingress.yaml
+++ b/classification/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -9,6 +10,16 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
   rules:
     - host: {{ .Values.ingress.host }}
       http:
@@ -17,3 +28,4 @@ spec:
             backend:
               serviceName: {{ template "signals-classification.fullname" . }}
               servicePort: http
+{{- end }}

--- a/classification/values.yaml
+++ b/classification/values.yaml
@@ -29,12 +29,18 @@ service:
   port: 80
 
 ingress:
-  host: classification.signals.local
+  enabled: true
   annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     ingress.kubernetes.io/hsts-include-subdomains: "true"
     ingress.kubernetes.io/hsts-max-age: "315360000"
     ingress.kubernetes.io/hsts-preload: "true"
     ingress.kubernetes.io/ssl-redirect: "true"
+  host: classification.signals.local
+  tls:
+    - secretName: classification-tls
+      hosts:
+        - classification.signals.local
 
 persistence:
   enabled: true


### PR DESCRIPTION
This PR makes it possible to configure the ingress of classification in a standardized way, e.g. enabling TLS.