### PR TITLE
Ability to configure persistent volume for datawarehouse

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -17,6 +17,12 @@ The backend Helm chart installs the Signalen API and the by default the followin
 | `image.tag` | The tag of the Docker image | `latest` |
 | `replicaCount` | The number of API replicas | `1` |
 | `workerReplicaCount` | The number of background worker replicas | `1` |
+| `persistence.media.enabled` | Enable persistence of media | `true` |
+| `persistence.media.size` | Specify the size of the media PVC | `1Gi` |
+| `persistence.media.existingClaim` | Name of an existing PVC to use | `null` |
+| `persistence.datawarehouse.enabled` | Enable persistence of datawarehouse | `false` |
+| `persistence.datawarehouse.size` | Specify the size of the datawarehouse PVC | `1Gi` |
+| `persistence.datawarehouse.existingClaim` | Name of an existing PVC to use for datawarehouse | `null` |
 | `settings.allowedHosts` | Restrict the allowed hosts of the API | `*` |
 | `settings.defaultPdokMunicipalities` | A (comma-seperated) list of [PDOK municipalities](https://www.pdok.nl/introductie/-/article/cbs-wijken-en-buurten) the API allows complaints for (e.g. `"Amsterdam,'s-Hertogenbosch"`) | `""` |
 | `settings.organizationName` | The name of the organization | `"Signalen"` |

--- a/backend/templates/deployment.yaml
+++ b/backend/templates/deployment.yaml
@@ -128,16 +128,16 @@ spec:
               containerPort: 8000
       volumes:
         - name: media
-        {{- if .Values.persistence.enabled }}
+        {{- if .Values.persistence.media.enabled }}
           persistentVolumeClaim:
-            claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "signals-backend.fullname" . }}{{- end }}
+            claimName: {{ if .Values.persistence.media.existingClaim }}{{ .Values.persistence.media.existingClaim }}{{- else }}{{ template "signals-backend.fullname" . }}{{- end }}
         {{- else }}
           emptyDir: {}
         {{- end }}
         - name: dwh-media
-        {{- if .Values.persistence.enabled }}
+        {{- if .Values.persistence.datawarehouse.enabled }}
           persistentVolumeClaim:
-            claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "signals-backend.fullname" . }}{{- end }}
+            claimName: {{ if .Values.persistence.datawarehouse.existingClaim }}{{ .Values.persistence.datawarehouse.existingClaim }}{{- else }}{{ template "signals-backend.fullname" . }}-datawarehouse{{- end }}
         {{- else }}
           emptyDir: {}
         {{- end }}

--- a/backend/templates/persistent-volume-claim.yaml
+++ b/backend/templates/persistent-volume-claim.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+{{- if and .Values.persistence.media.enabled (not .Values.persistence.media.existingClaim) }}
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -10,5 +11,20 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: {{ .Values.persistence.size }}
+      storage: {{ .Values.persistence.media.size }}
+{{- end }}
+{{- if and .Values.persistence.datawarehouse.enabled (not .Values.persistence.datawarehouse.existingClaim) }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "signals-backend.fullname" . }}-datawarehouse
+  labels:
+    {{- include "signals-backend.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.persistence.datawarehouse.size }}
 {{- end }}

--- a/backend/values.yaml
+++ b/backend/values.yaml
@@ -32,9 +32,14 @@ ingress:
         - api.signals.local
 
 persistence:
-  enabled: true
-  size: 1Gi
-  existingClaim: null
+  media:
+    enabled: true
+    size: 1Gi
+    existingClaim: null
+  datawarehouse:
+    enabled: false
+    size: 1Gi
+    existingClaim: null
 
 settings:
   allowedHosts: "*"


### PR DESCRIPTION
This PR is breaking with the current version of the Helm chart, so we should tag a new MAJOR version. Values need to be updated as follows:

- `persistence.enabled` -> `persistence.media.enabled`
- `persistence.size` -> `persistence.media.size`
- `persistence.existingClaim` -> `persistence.media.existingClaim`
