### PR TITLE
Upgrade Elasticsearch to 6.8.21

### DIFF
--- a/charts/backend/Chart.lock
+++ b/charts/backend/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 6.14.2
 - name: elasticsearch
   repository: https://helm.elastic.co
-  version: 6.8.13
-digest: sha256:c16420bd8e98a25c44fc5c33061d6d9407971f07bc88c608a8a15863275f9ce8
-generated: "2020-12-22T19:07:54.082297+01:00"
+  version: 6.8.21
+digest: sha256:4ce3cd4ce988793214f2c3a4ca6afcbe046c428d653e62913380013440629003
+generated: "2021-12-16T12:44:31.737247+01:00"

--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backend
 description: The API for the Signals application
 type: application
-version: 2.6.1
+version: 2.6.2
 
 dependencies:
   - name: postgresql

--- a/charts/classification/Chart.yaml
+++ b/charts/classification/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: classification
 description: Machine learning prediction API
 type: application
-version: 2.6.1
+version: 2.6.2

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: frontend
 description: The web frontend for the Signals application
 type: application
-version: 2.6.1
+version: 2.6.2

--- a/charts/mapserver/Chart.yaml
+++ b/charts/mapserver/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: mapserver
 description: A chart that deploys Mapserver
 type: application
-version: 2.6.1
+version: 2.6.2


### PR DESCRIPTION
Release notes: https://www.elastic.co/guide/en/elasticsearch/reference/6.8/release-notes-6.8.21.html