### PR TITLE
UWSGI buffersize to 8192 and chart version bump to 2.6.2

### DIFF
--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backend
 description: The API for the Signals application
 type: application
-version: 2.6.1
+version: 2.6.2
 
 dependencies:
   - name: postgresql

--- a/charts/backend/templates/deployment.yaml
+++ b/charts/backend/templates/deployment.yaml
@@ -51,6 +51,7 @@ spec:
             - '--master'
             - '--http=:8000'
             - '--module=signals.wsgi:application'
+            - '--buffer-size=8192'
             - '--processes={{ .Values.uwsgi.processes }}'
             - '--threads={{ .Values.uwsgi.threads }}'
             - '--static-map=/signals/static=/static'

--- a/charts/classification/Chart.yaml
+++ b/charts/classification/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: classification
 description: Machine learning prediction API
 type: application
-version: 2.6.1
+version: 2.6.2

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: frontend
 description: The web frontend for the Signals application
 type: application
-version: 2.6.1
+version: 2.6.2

--- a/charts/mapserver/Chart.yaml
+++ b/charts/mapserver/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: mapserver
 description: A chart that deploys Mapserver
 type: application
-version: 2.6.1
+version: 2.6.2


### PR DESCRIPTION
Increase the UWSGI buffer size to allow longer querystrings and thus more complex filtering on the Signals endpoint. Bump version of Helm charts to 2.6.2.