### PR TITLE
Update to v 2.6.3, configure EXCLUDED_PERMISSIONS_IN_RESPONSE setting…

### DIFF
--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backend
 description: The API for the Signals application
 type: application
-version: 2.6.2
+version: 2.6.3
 
 dependencies:
   - name: postgresql

--- a/charts/backend/README.md
+++ b/charts/backend/README.md
@@ -52,11 +52,11 @@ The backend Helm chart installs the Signalen API and the by default the followin
 | `settings.email.restEndpointClientCert` | The path to the client certificate when using REST backend | `""` |
 | `settings.email.restEndpointClientKey` | The path to the client key when using REST backend | `""` |
 | `settings.celeryEmailBackend` | The e-mail backend to use (SMTP or REST) | `django.core.mail.backends.smtp.EmailBackend` |
-| `settings.feedbackEnvFeMapping` | The URL of the frontend (deprecated) | `https://meldingen.amsterdam.nl` |
 | `settings.frontendUrl` | The URL of the frontend | `""` |
 | `settings.classificationEndpoint` | Use SSL while connecting to the SMTP server | `https://api.data.amsterdam.nl/signals_mltool` |
 | `settings.enablePublicGeoSignalEndpoint` | Enable public endpoint for viewing Signals | `false` |
 | `settings.allowInvalidAddressAsUnverified` | Allow a backoffice employee to enter an unknown address | `true` |
+| `settings.excludedPermissionsInResponses` | sia_ permissions to hide from backoffice settings page | `sia_delete_attachment_of_normal_signal, sia_delete_attachment_of_parent_signal, sia_delete_attachment_of_child_signal, sia_delete_attachment_of_other_user` |
 | `sigmax.enabled` | Enable the connection with Sigmax City Control | `false` |
 | `sigmax.serverUrl` | The server URL of Sigmax | `` |
 | `sigmax.authToken` | The token to authenticate with Sigmax | `` |

--- a/charts/backend/templates/configmap.yaml
+++ b/charts/backend/templates/configmap.yaml
@@ -38,7 +38,6 @@ data:
   ELASTICSEARCH_INDEX: {{ .Values.settings.elasticsearch.index | quote }}
   ENABLE_PUBLIC_GEO_SIGNAL_ENDPOINT: {{ if .Values.settings.enablePublicGeoSignalEndpoint }}"True"{{ else }}"False"{{ end }}
   ENVIRONMENT: {{ .Values.settings.environment | quote }}
-  FEEDBACK_ENV_FE_MAPPING: {{ .Values.settings.feedbackEnvFeMapping | quote }}
   FRONTEND_URL: {{ .Values.settings.frontendUrl | quote }}
   JWKS_URL: {{ .Values.settings.jwksUrl | quote }}
   ORGANIZATION_NAME: {{ .Values.settings.organizationName | quote }}
@@ -51,3 +50,4 @@ data:
   SIGNALS_ML_TOOL_ENDPOINT: {{ .Values.settings.classificationEndpoint | quote }}
   USER_ID_FIELD: {{ .Values.settings.userIdField | quote }}
   USER_ID_FIELDS: {{ .Values.settings.userIdField | quote }}
+  EXCLUDED_PERMISSIONS_IN_RESPONSE: {{ .Values.settings.excludedPermissionsInResponses }}

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -74,6 +74,12 @@ settings:
   apiTransformSourceBasedOnReporterDomainExtensions: "@localhost"
   apiTransformSourceBasedOnReporterExceptions: "ignore@localhost"
 
+  excludedPermissionsInResponses: >-
+    sia_delete_attachment_of_normal_signal,
+    sia_delete_attachment_of_parent_signal,
+    sia_delete_attachment_of_child_signal,
+    sia_delete_attachment_of_other_user
+
   apiPdfLogoStaticFile: api/logo-gemeente-amsterdam.svg
 
   database:
@@ -108,8 +114,7 @@ settings:
   celeryEmailBackend: django.core.mail.backends.smtp.EmailBackend
 
   datapuntApiUrl: https://api.data.amsterdam.nl/
-  feedbackEnvFeMapping: https://meldingen.amsterdam.nl
-  frontendUrl: ""
+  frontendUrl: ""  # URL pointing to Signalen frontend (back office)
 
   classificationEndpoint: https://api.data.amsterdam.nl/signals_mltool
 

--- a/charts/classification/Chart.yaml
+++ b/charts/classification/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: classification
 description: Machine learning prediction API
 type: application
-version: 2.6.2
+version: 2.6.3

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: frontend
 description: The web frontend for the Signals application
 type: application
-version: 2.6.2
+version: 2.6.3

--- a/charts/mapserver/Chart.yaml
+++ b/charts/mapserver/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: mapserver
 description: A chart that deploys Mapserver
 type: application
-version: 2.6.2
+version: 2.6.3


### PR DESCRIPTION
Add support for `EXCLUDED_PERMISSIONS_IN_RESPONSE` to backend helm chart by setting `settings.excludedPermissionsInResponses`. This allows hiding `sia_*` permissions from the back office settings page. For now the default value is:
```
sia_delete_attachment_of_normal_signal, sia_delete_attachment_of_parent_signal, sia_delete_attachment_of_child_signal, sia_delete_attachment_of_other_user
```
That default matches the default in the Signalen Django settings.

Furthermore this helm chart release removes support for `feedbackEnvFeMapping` (that mapped to `FEEDBACK_ENV_FE_MAPPING` used by older releases of the Signalen backend).

This Helm Chart can be used with version 2.5.0 of the Signalen backend.