### PR TITLE
Remove extraneous spaces in settings.excludedPermissionsInResponses

### DIFF
--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backend
 description: The API for the Signals application
 type: application
-version: 2.6.3
+version: 2.6.4
 
 dependencies:
   - name: postgresql

--- a/charts/backend/templates/configmap.yaml
+++ b/charts/backend/templates/configmap.yaml
@@ -50,4 +50,4 @@ data:
   SIGNALS_ML_TOOL_ENDPOINT: {{ .Values.settings.classificationEndpoint | quote }}
   USER_ID_FIELD: {{ .Values.settings.userIdField | quote }}
   USER_ID_FIELDS: {{ .Values.settings.userIdField | quote }}
-  EXCLUDED_PERMISSIONS_IN_RESPONSE: {{ .Values.settings.excludedPermissionsInResponses }}
+  EXCLUDED_PERMISSIONS_IN_RESPONSE: {{ .Values.settings.excludedPermissionsInResponses | nospace | quote }}

--- a/charts/classification/Chart.yaml
+++ b/charts/classification/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: classification
 description: Machine learning prediction API
 type: application
-version: 2.6.3
+version: 2.6.4

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: frontend
 description: The web frontend for the Signals application
 type: application
-version: 2.6.3
+version: 2.6.4

--- a/charts/mapserver/Chart.yaml
+++ b/charts/mapserver/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: mapserver
 description: A chart that deploys Mapserver
 type: application
-version: 2.6.3
+version: 2.6.4


### PR DESCRIPTION
Fix problem with extra spaces introduced by YAML processing that break the filtering of permissions that are available through the API. Bumped Helm Chart version to 2.6.4.