### PR TITLE
Start using appVersion for versioning the Signalen application

### DIFF
--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,8 @@ apiVersion: v2
 name: backend
 description: The API for the Signals application
 type: application
-version: 2.6.5
+version: 2.6.6
+appVersion: 2.5.0
 
 dependencies:
   - name: postgresql

--- a/charts/backend/templates/deployment-celery-beat.yaml
+++ b/charts/backend/templates/deployment-celery-beat.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         - name: celery-beat
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/usr/local/bin/celery"]
           args:

--- a/charts/backend/templates/deployment-celery-worker.yaml
+++ b/charts/backend/templates/deployment-celery-worker.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - name: celery-worker
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/usr/local/bin/celery"]
           args:

--- a/charts/backend/templates/deployment.yaml
+++ b/charts/backend/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         fsGroup: 999
       initContainers:
         - name: migrate
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /usr/local/bin/python
@@ -43,7 +43,7 @@ spec:
                 name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "signals-backend.fullname" . }}{{ end }}
       containers:
         - name: api
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /usr/local/bin/uwsgi

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -17,7 +17,7 @@ deploymentStrategy: RollingUpdate
 
 image:
   repository: signalen/backend
-  tag: latest
+  tag: ""
   pullPolicy: IfNotPresent
 
 podAnnotations: {}

--- a/charts/classification/Chart.yaml
+++ b/charts/classification/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v2
 name: classification
 description: Machine learning prediction API
 type: application
-version: 2.6.5
+version: 2.6.6
+appVersion: 47000c5f9b9a21aec846f3de53108d5df25acd28

--- a/charts/classification/values.yaml
+++ b/charts/classification/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: signalen/classification
-  tag: latest
+  tag: ""
   pullPolicy: IfNotPresent
 
 signalsCategoryUrl: https://backend.signalen.demoground.nl/signals/v1/public/terms

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v2
 name: frontend
 description: The web frontend for the Signals application
 type: application
-version: 2.6.5
+version: 2.6.6
+appVersion: v2.4.7

--- a/charts/frontend/templates/deployment.yaml
+++ b/charts/frontend/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:
             httpGet:

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: signalen/frontend
-  tag: latest
+  tag: ""
   pullPolicy: IfNotPresent
 
 podAnnotations: {}


### PR DESCRIPTION
This proposal starts using [appVersion for versions](https://helm.sh/docs/topics/charts/#the-appversion-field). This improves usability of Helm chart users.