### PR TITLE
Add support for new-style history tracking in Signalen + release 2.6.6

### DIFF
--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backend
 description: The API for the Signals application
 type: application
-version: 2.6.5
+version: 2.6.6
 
 dependencies:
   - name: postgresql

--- a/charts/backend/README.md
+++ b/charts/backend/README.md
@@ -59,6 +59,7 @@ The backend Helm chart installs the Signalen API and the by default the followin
 | `settings.excludedPermissionsInResponses` | sia_ permissions to hide from backoffice settings page | `sia_delete_attachment_of_normal_signal, sia_delete_attachment_of_parent_signal, sia_delete_attachment_of_child_signal, sia_delete_attachment_of_other_user` |
 | `settings.systemMailFeedbackReceivedEnabled` | Send email on reception of feedback | `false` |
 | `settings.reporterMailHandledNegativeContactEnabled` | Allow transition VERZOEK_TOT_HEROPENEN to AFGEHANDELD to send a mail to reporter  | `false` |
+| `settings.signalHistoryLogEnabled` | Enable new-style history log | `false` |
 | `sigmax.enabled` | Enable the connection with Sigmax City Control | `false` |
 | `sigmax.serverUrl` | The server URL of Sigmax | `` |
 | `sigmax.authToken` | The token to authenticate with Sigmax | `` |

--- a/charts/backend/templates/configmap.yaml
+++ b/charts/backend/templates/configmap.yaml
@@ -53,3 +53,4 @@ data:
   EXCLUDED_PERMISSIONS_IN_RESPONSE: {{ .Values.settings.excludedPermissionsInResponses | nospace | quote }}
   SYSTEM_MAIL_FEEDBACK_RECEIVED_ENABLED: {{ if .Values.settings.systemMailFeedbackReceivedEnabled }}"True"{{ else }}"False"{{ end }}
   REPORTER_MAIL_HANDLED_NEGATIVE_CONTACT_ENABLED: {{ if .Values.settings.reporterMailHandledNegativeContactEnabled }}"True"{{ else }}"False"{{ end }}
+  SIGNAL_HISTORY_LOG_ENABLED: {{ if .Values.settings.signalHistoryLogEnabled }}"True"{{ else }}"False"{{ end }}

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -83,6 +83,7 @@ settings:
   apiPdfLogoStaticFile: api/logo-gemeente-amsterdam.svg
   systemMailFeedbackReceivedEnabled: false
   reporterMailHandledNegativeContactEnabled: false
+  signalHistoryLogEnabled: false
 
   database:
     host: signalen-backend-postgresql

--- a/charts/classification/Chart.yaml
+++ b/charts/classification/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: classification
 description: Machine learning prediction API
 type: application
-version: 2.6.5
+version: 2.6.6

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: frontend
 description: The web frontend for the Signals application
 type: application
-version: 2.6.5
+version: 2.6.6

--- a/charts/mapserver/Chart.yaml
+++ b/charts/mapserver/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: mapserver
 description: A chart that deploys Mapserver
 type: application
-version: 2.6.5
+version: 2.6.6


### PR DESCRIPTION
Add support for new-style history tracking in Signalen by making the `SIGNAL_HISTORY_LOG_ENABLED` feature flag configurable. Default configuration is to not turn it on and continue using the old history implementation. This will be revisited in the future when our installations have transitioned to the new style history.

