### PR TITLE
Add networking.k8s.io/v1 support for ingress for Kubernetes 1.22+ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ helm upgrade --install \
   --set "settings.userIdField=email" \
   --set "settings.classificationEndpoint=https://classification.signals.example.com/signals_mltool" \
   --set "ingress.enabled=true" \
-  --set "ingress.host=api.signals.example.com"
+  --set "ingress.hosts[0]=api.signals.example.com"
 ```
 
 And install the frontend chart:
@@ -67,7 +67,7 @@ helm upgrade --install \
   --set "oidc.authEndpoint=https://dex.signals.example.com/auth" \
   --set "config.apiBaseUrl=https://api.signals.example.com/signals" \
   --set "ingress.enabled=true" \
-  --set "ingress.host=signals.example.com"
+  --set "ingress.hosts[0]=signals.example.com"
 ```
 
 And install the classification chart:
@@ -79,7 +79,7 @@ helm upgrade --install \
   --namespace signalen \
   --set "signalsCategoryUrl=https://api.signals.example.com/signals/v1/public/terms" \
   --set "ingress.enabled=true" \
-  --set "ingress.host=classification.signals.example.com"
+  --set "ingress.hosts[0]=classification.signals.example.com"
 ```
 
 ## Uninstall the charts

--- a/charts/backend/Chart.lock
+++ b/charts/backend/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 7.7.3
+  version: 11.6.12
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
-  version: 6.14.2
+  version: 9.1.4
 - name: elasticsearch
   repository: https://helm.elastic.co
-  version: 6.8.13
-digest: sha256:c16420bd8e98a25c44fc5c33061d6d9407971f07bc88c608a8a15863275f9ce8
-generated: "2020-12-22T19:07:54.082297+01:00"
+  version: 6.8.22
+digest: sha256:05042be71bb683057d00967fd7be00662702ec199a78a94e80b76c498f3baeee
+generated: "2022-07-01T13:03:33.557878+02:00"

--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -6,12 +6,12 @@ version: 2.6.6
 
 dependencies:
   - name: postgresql
-    version: ~7.7.2
+    version: ~11.6.12
     repository: https://charts.bitnami.com/bitnami
     tags:
       - postgresql
   - name: rabbitmq
-    version: ~6.14.0
+    version: ~9.1.4
     repository: https://charts.bitnami.com/bitnami
     tags:
       - rabbitmq

--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backend
 description: The API for the Signals application
 type: application
-version: 2.6.6
+version: 3.0.0
 
 dependencies:
   - name: postgresql

--- a/charts/backend/README.md
+++ b/charts/backend/README.md
@@ -65,6 +65,7 @@ The backend Helm chart installs the Signalen API and the by default the followin
 | `sigmax.authToken` | The token to authenticate with Sigmax | `` |
 | `ingress.enabled` | Expose the API through an ingress | `true` |
 | `ingress.annotations` | Additional annotations on the API ingress | `{}` |
-| `ingress.host` | The host of the API | `""` |
+| `ingress.hosts` | The hosts of the ingress | `{}` |
+| `ingress.tls` | The TLS settings of the ingress | `{}` |
 
 Check [values.yaml](./values.yaml) for all the possible configuration options.

--- a/charts/backend/templates/ingress.yaml
+++ b/charts/backend/templates/ingress.yaml
@@ -1,12 +1,21 @@
 {{- if .Values.ingress.enabled -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- $fullName := include "signals-backend.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: {{ template "signals-backend.fullname" . }}
+  name: {{ $fullName }}
   labels:
     {{- include "signals-backend.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
@@ -14,22 +23,39 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
-{{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
   rules:
-    - host: {{ .Values.ingress.host }}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
       http:
         paths:
-          - path: /signals
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
-              serviceName: {{ template "signals-backend.fullname" . }}
-              servicePort: {{ .Values.service.port }}
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -28,9 +28,16 @@ service:
 
 ingress:
   enabled: true
+  className: ""
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: 8m
-  host: api.signals.local
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: api.signals.local
+      paths:
+        - path: /signals
+          pathType: ImplementationSpecific
   tls:
     - secretName: backend-tls
       hosts:

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -133,22 +133,21 @@ settings:
 ## PostgreSQL subchart ##
 #########################
 postgresql:
-  persistence:
-    enabled: false
-    size: 1Gi
-    existingClaim: null
+  auth:
+    postgresPassword: signalen
+    database: signalen
 
-  postgresqlDatabase: signalen
-  postgresqlPassword: signalen
+  primary:
+    persistence:
+      enabled: false
+      size: 1Gi
+      existingClaim: null
 
 #######################
 ## RabbitMQ subchart ##
 #######################
 rabbitmq:
-  image:
-    tag: "3.8"
-
-  rabbitmq:
+  auth:
     username: signalen
     password: signalen
 

--- a/charts/classification/Chart.yaml
+++ b/charts/classification/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: classification
 description: Machine learning prediction API
 type: application
-version: 2.6.6
+version: 3.0.0

--- a/charts/classification/README.md
+++ b/charts/classification/README.md
@@ -18,6 +18,7 @@ The classification service expects a trained machine learning model in the folde
 | `persistence.accessModes` | The accessModes of the PVC | `{ ReadWriteOnce }` |
 | `ingress.enabled` | Expose the API through an ingress | `true` |
 | `ingress.annotations` | Additional annotations on the API ingress | `{}` |
-| `ingress.host` | The host of the API | `""` |
+| `ingress.hosts` | The hosts of the ingress | `{}` |
+| `ingress.tls` | The TLS settings of the ingress | `{}` |
 
 Check [values.yaml](./values.yaml) for all the possible configuration options.

--- a/charts/classification/templates/ingress.yaml
+++ b/charts/classification/templates/ingress.yaml
@@ -1,8 +1,21 @@
 {{- if .Values.ingress.enabled -}}
+{{- $fullName := include "signals-classification.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
-  name: {{ template "signals-classification.fullname" . }}
+  name: {{ $fullName }}
   labels:
     {{- include "signals-classification.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
@@ -10,22 +23,39 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
-{{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
   rules:
-    - host: {{ .Values.ingress.host }}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
       http:
         paths:
-          - path: /
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
-              serviceName: {{ template "signals-classification.fullname" . }}
-              servicePort: http
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/classification/values.yaml
+++ b/charts/classification/values.yaml
@@ -30,8 +30,15 @@ service:
 
 ingress:
   enabled: true
+  className: ""
   annotations: {}
-  host: classification.signals.local
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: classification.signals.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
   tls:
     - secretName: classification-tls
       hosts:

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: frontend
 description: The web frontend for the Signals application
 type: application
-version: 2.6.6
+version: 3.0.0

--- a/charts/frontend/README.md
+++ b/charts/frontend/README.md
@@ -12,6 +12,7 @@ This Helm chart contains the Signalen web frontend.
 | `config` | The configuration of the frontend. For all options see [environment.conf.json](https://github.com/Signalen/frontend/blob/develop/environment.conf.json) | `{}` |
 | `ingress.enabled` | Expose the API through an ingress | `true` |
 | `ingress.annotations` | Additional annotations on the API ingress | `{}` |
-| `ingress.host` | The host of the API | `""` |
+| `ingress.hosts` | The hosts of the ingress | `{}` |
+| `ingress.tls` | The TLS settings of the ingress | `{}` |
 
 Check [values.yaml](./values.yaml) for all the possible configuration options.

--- a/charts/frontend/templates/ingress.yaml
+++ b/charts/frontend/templates/ingress.yaml
@@ -1,8 +1,21 @@
 {{- if .Values.ingress.enabled -}}
+{{- $fullName := include "signals-frontend.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
-  name: {{ template "signals-frontend.fullname" . }}
+  name: {{ $fullName }}
   labels:
     {{- include "signals-frontend.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
@@ -10,22 +23,39 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ingress.tls }}
-  tls:
-  {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
-{{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
   rules:
-    - host: {{ .Values.ingress.host }}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
       http:
         paths:
-          - path: /
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
-              serviceName: {{ template "signals-frontend.fullname" . }}
-              servicePort: http
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -13,8 +13,15 @@ service:
 
 ingress:
   enabled: true
+  className: ""
   annotations: {}
-  host: frontend.signals.local
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: frontend.signals.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
   tls:
     - secretName: frontend-tls
       hosts:

--- a/charts/mapserver/Chart.yaml
+++ b/charts/mapserver/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: mapserver
 description: A chart that deploys Mapserver
 type: application
-version: 2.6.6
+version: 3.0.0

--- a/charts/mapserver/README.md
+++ b/charts/mapserver/README.md
@@ -16,6 +16,7 @@ This Helm chart can be used to install [Mapserver](https://www.mapserver.org/).
 | `persistence.accessModes` | The accessModes of the PVC | `{ ReadWriteOnce }` |
 | `ingress.enabled` | Expose through an ingress | `true` |
 | `ingress.annotations` | Additional annotations on the ingress | `{}` |
-| `ingress.hosts` | The hosts of the ingress | `{ mapserver.signals.local }` |
+| `ingress.hosts` | The hosts of the ingress | `{}` |
+| `ingress.tls` | The TLS settings of the ingress | `{}` |
 
 Check [values.yaml](./values.yaml) for all the possible configuration options. For some example data see [./example-data](./example-data).

--- a/charts/mapserver/templates/ingress.yaml
+++ b/charts/mapserver/templates/ingress.yaml
@@ -1,7 +1,14 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "mapserver.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -16,6 +23,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -28,12 +38,24 @@ spec:
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ . | quote }}
+    - host: {{ .host | quote }}
       http:
         paths:
-          - path: /
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
     {{- end }}
-  {{- end }}
+{{- end }}

--- a/charts/mapserver/values.yaml
+++ b/charts/mapserver/values.yaml
@@ -36,6 +36,7 @@ service:
 
 ingress:
   enabled: false
+  className: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
This PR adds support for networking.k8s.io/v1 for the ingress definition. This is required for Kubernetes 1.22+

⚠️ This is a breaking change and requires users to update `ingress.host` values to the `ingress.hosts` format. This new format is in line with the default Helm charts. For example for the backend, change values from:

```yaml
ingress:
  host: api.signals.local
```

to

```yaml
ingress:
  hosts:
    - host: api.signals.local
      paths:
        - path: /signals
          pathType: ImplementationSpecific
```
