### PR TITLE
Update rabbitmq and postgresql helm chart versions

### DIFF
--- a/charts/backend/Chart.lock
+++ b/charts/backend/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 7.7.3
+  version: 11.6.12
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
-  version: 6.14.2
+  version: 9.1.4
 - name: elasticsearch
   repository: https://helm.elastic.co
-  version: 6.8.13
-digest: sha256:c16420bd8e98a25c44fc5c33061d6d9407971f07bc88c608a8a15863275f9ce8
-generated: "2020-12-22T19:07:54.082297+01:00"
+  version: 6.8.22
+digest: sha256:05042be71bb683057d00967fd7be00662702ec199a78a94e80b76c498f3baeee
+generated: "2022-07-01T13:03:33.557878+02:00"

--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -6,12 +6,12 @@ version: 2.6.6
 
 dependencies:
   - name: postgresql
-    version: ~7.7.2
+    version: ~11.6.12
     repository: https://charts.bitnami.com/bitnami
     tags:
       - postgresql
   - name: rabbitmq
-    version: ~6.14.0
+    version: ~9.1.4
     repository: https://charts.bitnami.com/bitnami
     tags:
       - rabbitmq

--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backend
 description: The API for the Signals application
 type: application
-version: 2.6.6
+version: 3.0.0
 
 dependencies:
   - name: postgresql

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -133,22 +133,21 @@ settings:
 ## PostgreSQL subchart ##
 #########################
 postgresql:
-  persistence:
-    enabled: false
-    size: 1Gi
-    existingClaim: null
+  auth:
+    postgresPassword: signalen
+    database: signalen
 
-  postgresqlDatabase: signalen
-  postgresqlPassword: signalen
+  primary:
+    persistence:
+      enabled: false
+      size: 1Gi
+      existingClaim: null
 
 #######################
 ## RabbitMQ subchart ##
 #######################
 rabbitmq:
-  image:
-    tag: "3.8"
-
-  rabbitmq:
+  auth:
     username: signalen
     password: signalen
 

--- a/charts/classification/Chart.yaml
+++ b/charts/classification/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: classification
 description: Machine learning prediction API
 type: application
-version: 2.6.6
+version: 3.0.0

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: frontend
 description: The web frontend for the Signals application
 type: application
-version: 2.6.6
+version: 3.0.0

--- a/charts/mapserver/Chart.yaml
+++ b/charts/mapserver/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: mapserver
 description: A chart that deploys Mapserver
 type: application
-version: 2.6.6
+version: 3.0.0


### PR DESCRIPTION
Update postgresql and rabbitmq Helm charts, this should fix broken release 2.6.6.