### PR TITLE
Add support for adding extra environment variables through env, envVars and envFrom

### DIFF
--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backend
 description: The API for the Signals application
 type: application
-version: 4.2.2
+version: 4.2.3
 appVersion: 2.7.1
 
 dependencies:

--- a/charts/backend/README.md
+++ b/charts/backend/README.md
@@ -33,6 +33,9 @@ The backend Helm chart installs the Signalen API and the by default the followin
 | `existingSecret` | Name of an existing secret to avoid managing secrets through Helm | `null` |
 | `extraVolumes` | Ability to add exta volumes | `[]` |
 | `extraVolumeMounts` | Ability to add exta volume mounts | `[]` |
+| `envFrom` | Additional environment variables mounted from [secrets](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables) or [config maps](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables). | `[]` |
+| `env` | Additional environment variables passed directly to containers. | `{}` |
+| `envVars` | Similar to env but with support for all possible configurations. | `[]` |
 | `settings.secretKey` | The secret key of the backend | `change-to-something-secret` |
 | `settings.allowedHosts` | Restrict the allowed hosts of the API | `*` |
 | `settings.defaultPdokMunicipalities` | A (comma-seperated) list of [PDOK municipalities](https://www.pdok.nl/introductie/-/article/cbs-wijken-en-buurten) the API allows complaints for (e.g. `"Amsterdam,'s-Hertogenbosch"`) | `""` |

--- a/charts/backend/templates/deployment-celery-beat.yaml
+++ b/charts/backend/templates/deployment-celery-beat.yaml
@@ -32,8 +32,19 @@ spec:
             - 'beat'
             - '--loglevel=WARNING'
             - '--pidfile=/tmp/celerybeat.pid'
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- with .Values.envVars }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ template "signals-backend.fullname" . }}
             - secretRef:
                 name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "signals-backend.fullname" . }}{{ end }}
+          {{- with .Values.envFrom }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/charts/backend/templates/deployment-celery-worker.yaml
+++ b/charts/backend/templates/deployment-celery-worker.yaml
@@ -35,11 +35,22 @@ spec:
             - 'worker'
             - '--loglevel=WARNING'
             - '--concurrency={{ .Values.celery.concurrency }}'
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- with .Values.envVars }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ template "signals-backend.fullname" . }}
             - secretRef:
                 name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "signals-backend.fullname" . }}{{ end }}
+          {{- with .Values.envFrom }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: dwh-media
               mountPath: /dwh_media

--- a/charts/backend/templates/deployment.yaml
+++ b/charts/backend/templates/deployment.yaml
@@ -36,11 +36,22 @@ spec:
           args:
             - '/app/manage.py'
             - 'migrate'
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- with .Values.envVars }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ template "signals-backend.fullname" . }}
             - secretRef:
                 name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "signals-backend.fullname" . }}{{ end }}
+          {{- with .Values.envFrom }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       containers:
         - name: api
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -57,11 +68,22 @@ spec:
             - '--static-map=/signals/static=/static'
             - '--static-map=/signals/media=/media'
             - '--die-on-term'
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- with .Values.envVars }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ template "signals-backend.fullname" . }}
             - secretRef:
                 name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "signals-backend.fullname" . }}{{ end }}
+          {{- with .Values.envFrom }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: media
               mountPath: /media

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -64,6 +64,30 @@ existingSecret: null # Refer to existing secret to avoid managing secrets throug
 extraVolumes: []
 extraVolumeMounts: []
 
+# -- Additional environment variables mounted from [secrets](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables) or [config maps](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables).
+# See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables) for details.
+envFrom: []
+
+# -- Additional environment variables passed directly to containers.
+# See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables) for details.
+env: {}
+
+# -- Similar to env but with support for all possible configurations.
+# See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables) for details.
+envVars: []
+# - name: SOME_ENV_VAR
+#   value: value
+# - name: SOME_ENV_VAR2
+#   valueFrom:
+#     secretKeyRef:
+#       name: secret-name
+#       key: secret-key
+# - name: SOME_ENV_VAR3
+#   valueFrom:
+#     configMapKeyRef:
+#       name: config-map-name
+#       key: config-map-key
+
 settings:
   secretKey: "change-to-something-secret"
   allowedHosts: "*"

--- a/charts/classification/Chart.yaml
+++ b/charts/classification/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: classification
 description: Machine learning prediction API
 type: application
-version: 4.2.2
+version: 4.2.3
 appVersion: 47000c5f9b9a21aec846f3de53108d5df25acd28

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: frontend
 description: The web frontend for the Signals application
 type: application
-version: 4.2.2
+version: 4.2.3
 appVersion: v2.6.2


### PR DESCRIPTION
This PR allows a chart user to add extra environment variables to the backend chart. This can be used for example for feature flags that are not available (yet) in the Helm chart.

- envFrom: Additional environment variables mounted from [secrets](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables) or [config maps](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables).
- env: Additional environment variables passed directly to containers.
- envVars: Similar to env but with support for all possible configurations.