### PR TITLE
Only set storageClassName field when it is configured

### DIFF
--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backend
 description: The API for the Signals application
 type: application
-version: 4.2.1
+version: 4.2.2
 appVersion: 2.7.1
 
 dependencies:

--- a/charts/backend/templates/persistent-volume-claim.yaml
+++ b/charts/backend/templates/persistent-volume-claim.yaml
@@ -12,7 +12,9 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.media.size }}
+{{- if .Values.persistence.media.storageClassName }}
   storageClassName: {{ .Values.persistence.media.storageClassName | quote }}
+{{- end }}
 {{- end }}
 {{- if and .Values.persistence.datawarehouse.enabled (not .Values.persistence.datawarehouse.existingClaim) }}
 ---
@@ -28,5 +30,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.datawarehouse.size }}
+{{- if .Values.persistence.datawarehouse.storageClassName }}
   storageClassName: {{ .Values.persistence.datawarehouse.storageClassName | quote }}
+{{- end }}
 {{- end }}

--- a/charts/classification/Chart.yaml
+++ b/charts/classification/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: classification
 description: Machine learning prediction API
 type: application
-version: 4.2.1
+version: 4.2.2
 appVersion: 47000c5f9b9a21aec846f3de53108d5df25acd28

--- a/charts/classification/templates/persistent-volume-claim.yaml
+++ b/charts/classification/templates/persistent-volume-claim.yaml
@@ -11,5 +11,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size }}
+{{- if .Values.persistence.storageClassName }}
   storageClassName: {{ .Values.persistence.storageClassName | quote }}
+{{- end }}
 {{- end }}

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: frontend
 description: The web frontend for the Signals application
 type: application
-version: 4.2.1
+version: 4.2.2
 appVersion: v2.6.2


### PR DESCRIPTION
By merging https://github.com/Signalen/helm-charts/pull/32 I broke the contract with our users.

I hoped this change would be _non-breaking_, but in fact it _is_ breaking as it tries to set `storageClassName` to an empty string, which is different from the default storage class.

This PR fixes this and only sets the field `storageClassName` when the string is not empty.