### PR TITLE
Add missing media PVC to worker

### DIFF
--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backend
 description: The API for the Signals application
 type: application
-version: 4.3.0
+version: 4.4.0
 appVersion: 2.7.2
 
 dependencies:

--- a/charts/backend/README.md
+++ b/charts/backend/README.md
@@ -21,11 +21,13 @@ The backend Helm chart installs the Signalen API and the by default the followin
 | `uwsgi.threads` | The number of uWSGI threads | `2` |
 | `celery.concurrency` | The number of Celery concurrent child processes | `2` |
 | `persistence.media.enabled` | Enable persistence of media | `true` |
+| `persistence.media.enabledOnWorker` | Enable persistence of media on worker | `false` |
 | `persistence.media.size` | Specify the size of the media PVC | `1Gi` |
 | `persistence.media.existingClaim` | Name of an existing PVC to use | `null` |
 | `persistence.media.accessModes` | The accessModes of media | `{ ReadWriteOnce }` |
 | `persistence.media.storageClassName` | The storageClassName of media | `""` |
 | `persistence.datawarehouse.enabled` | Enable persistence of datawarehouse | `false` |
+| `persistence.datawarehouse.enabledOnWorker` | Enable persistence of media on datawarehouse | `true` |
 | `persistence.datawarehouse.size` | Specify the size of the datawarehouse PVC | `1Gi` |
 | `persistence.datawarehouse.existingClaim` | Name of an existing PVC to use for datawarehouse | `null` |
 | `persistence.datawarehouse.accessModes` | The accessModes of datawarehouse | `{ ReadWriteMany }` |

--- a/charts/backend/templates/deployment-celery-worker.yaml
+++ b/charts/backend/templates/deployment-celery-worker.yaml
@@ -56,14 +56,23 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
+            - name: media
+              mountPath: /media
             - name: dwh-media
               mountPath: /dwh_media
 {{- if ne (len .Values.extraVolumeMounts) 0 }}
 {{ toYaml .Values.extraVolumeMounts | indent 12 }}
 {{- end }}
       volumes:
+        - name: media
+        {{- if and .Values.persistence.media.enabled .Values.persistence.media.enabledOnWorker }}
+          persistentVolumeClaim:
+            claimName: {{ if .Values.persistence.media.existingClaim }}{{ .Values.persistence.media.existingClaim }}{{ else }}{{ template "signals-backend.fullname" . }}{{ end }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
         - name: dwh-media
-        {{- if .Values.persistence.datawarehouse.enabled }}
+        {{- if and .Values.persistence.datawarehouse.enabled .Values.persistence.datawarehouse.enabledOnWorker }}
           persistentVolumeClaim:
             claimName: {{ if .Values.persistence.datawarehouse.existingClaim }}{{ .Values.persistence.datawarehouse.existingClaim }}{{ else }}{{ template "signals-backend.fullname" . }}-datawarehouse{{ end }}
         {{- else }}

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -51,6 +51,7 @@ ingress:
 persistence:
   media:
     enabled: true
+    enabledOnWorker: false
     size: 1Gi
     existingClaim: null
     accessModes:
@@ -58,6 +59,7 @@ persistence:
     storageClassName: ""
   datawarehouse:
     enabled: false
+    enabledOnWorker: true
     size: 1Gi
     existingClaim: null
     accessModes:

--- a/charts/classification/Chart.yaml
+++ b/charts/classification/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: classification
 description: Machine learning prediction API
 type: application
-version: 4.3.0
+version: 4.4.0
 appVersion: 47000c5f9b9a21aec846f3de53108d5df25acd28

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: frontend
 description: The web frontend for the Signals application
 type: application
-version: 4.3.0
+version: 4.4.0
 appVersion: v2.8.1


### PR DESCRIPTION
The Celery worker currently has no access to the media volume. When the Sigmax connection is enabled, the worker is not able to access the attachments of the files in the worker.

This PR fixes that behavior and also mounts the media volume in the worker, when `persistence.media.enabledOnWorker` is set to true