### PR TITLE
Make Celery loglevel configurable

### DIFF
--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backend
 description: The API for the Signals application
 type: application
-version: 4.4.0
+version: 4.4.1
 appVersion: 2.7.2
 
 dependencies:

--- a/charts/backend/README.md
+++ b/charts/backend/README.md
@@ -20,6 +20,7 @@ The backend Helm chart installs the Signalen API and the by default the followin
 | `uwsgi.processes` | The number of uWSGI processes | `4` |
 | `uwsgi.threads` | The number of uWSGI threads | `2` |
 | `celery.concurrency` | The number of Celery concurrent child processes | `2` |
+| `celery.loglevel` | The loglevel of Celery | `WARNING` |
 | `persistence.media.enabled` | Enable persistence of media | `true` |
 | `persistence.media.enabledOnWorker` | Enable persistence of media on worker | `false` |
 | `persistence.media.size` | Specify the size of the media PVC | `1Gi` |

--- a/charts/backend/templates/deployment-celery-beat.yaml
+++ b/charts/backend/templates/deployment-celery-beat.yaml
@@ -34,7 +34,7 @@ spec:
           args:
             - '--app=signals'
             - 'beat'
-            - '--loglevel=WARNING'
+            - '--loglevel={{ .Values.celery.loglevel }}'
             - '--pidfile=/tmp/celerybeat.pid'
           env:
             {{- range $key, $value := .Values.env }}

--- a/charts/backend/templates/deployment-celery-worker.yaml
+++ b/charts/backend/templates/deployment-celery-worker.yaml
@@ -37,7 +37,7 @@ spec:
           args:
             - '--app=signals'
             - 'worker'
-            - '--loglevel=WARNING'
+            - '--loglevel={{ .Values.celery.loglevel }}'
             - '--concurrency={{ .Values.celery.concurrency }}'
           env:
             {{- range $key, $value := .Values.env }}

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -11,6 +11,7 @@ uwsgi:
   threads: 2
 
 celery:
+  loglevel: WARNING
   concurrency: 2
 
 deploymentStrategy: RollingUpdate

--- a/charts/classification/Chart.yaml
+++ b/charts/classification/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: classification
 description: Machine learning prediction API
 type: application
-version: 4.4.0
+version: 4.4.1
 appVersion: 47000c5f9b9a21aec846f3de53108d5df25acd28

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: frontend
 description: The web frontend for the Signals application
 type: application
-version: 4.4.0
+version: 4.4.1
 appVersion: v2.8.1


### PR DESCRIPTION
This PR makes the Celery loglevel configurable with the value `celery.loglevel`. Default to `WARNING` to make this change non-breaking.