### PR TITLE
Do not exclude "delete attachment" permissions in responses

### DIFF
--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -115,11 +115,7 @@ settings:
   apiTransformSourceBasedOnReporterDomainExtensions: "@localhost"
   apiTransformSourceBasedOnReporterExceptions: "ignore@localhost"
 
-  excludedPermissionsInResponses: >-
-    sia_delete_attachment_of_normal_signal,
-    sia_delete_attachment_of_parent_signal,
-    sia_delete_attachment_of_child_signal,
-    sia_delete_attachment_of_other_user
+  excludedPermissionsInResponses: ""
 
   apiPdfLogoStaticFile: api/logo-gemeente-amsterdam.svg
   systemMailFeedbackReceivedEnabled: false


### PR DESCRIPTION
This makes sure the functionallity is working correctly by default.