### PR TITLE
Update paths to static and media directories

### DIFF
--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backend
 description: The API for the Signals application
 type: application
-version: 4.5.1
+version: 4.6.0
 appVersion: 2.9.1
 
 dependencies:

--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -3,7 +3,7 @@ name: backend
 description: The API for the Signals application
 type: application
 version: 4.6.0
-appVersion: 2.9.1
+appVersion: 2.15.4
 
 dependencies:
   - name: postgresql

--- a/charts/backend/templates/deployment-celery-worker.yaml
+++ b/charts/backend/templates/deployment-celery-worker.yaml
@@ -57,7 +57,7 @@ spec:
           {{- end }}
           volumeMounts:
             - name: media
-              mountPath: /media
+              mountPath: /app/media
             - name: dwh-media
               mountPath: /dwh_media
 {{- if ne (len .Values.extraVolumeMounts) 0 }}

--- a/charts/backend/templates/deployment.yaml
+++ b/charts/backend/templates/deployment.yaml
@@ -69,8 +69,8 @@ spec:
             - '--buffer-size=8192'
             - '--processes={{ .Values.uwsgi.processes }}'
             - '--threads={{ .Values.uwsgi.threads }}'
-            - '--static-map=/signals/static=/static'
-            - '--static-map=/signals/media=/media'
+            - '--static-map=/signals/static=/app/static'
+            - '--static-map=/signals/media=/app/media'
             - '--die-on-term'
           env:
             {{- range $key, $value := .Values.env }}
@@ -90,7 +90,7 @@ spec:
           {{- end }}
           volumeMounts:
             - name: media
-              mountPath: /media
+              mountPath: /app/media
             - name: dwh-media
               mountPath: /dwh_media
 {{- if ne (len .Values.extraVolumeMounts) 0 }}

--- a/charts/classification/Chart.yaml
+++ b/charts/classification/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: classification
 description: Machine learning prediction API
 type: application
-version: 4.5.1
+version: 4.6.0
 appVersion: 47000c5f9b9a21aec846f3de53108d5df25acd28

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: frontend
 description: The web frontend for the Signals application
 type: application
-version: 4.5.1
+version: 4.6.0
 appVersion: 2.11.3


### PR DESCRIPTION
Update paths to static and media directories as they've changed in:
https://github.com/Amsterdam/signals/commit/ff974f229e09bf0246294f46a44027caa3ee1d67

We need a new helm chart version to be able to use the new directory locations.