### PR TITLE
By default set enabledOnWorker to true

### DIFF
--- a/charts/backend/README.md
+++ b/charts/backend/README.md
@@ -22,7 +22,7 @@ The backend Helm chart installs the Signalen API and the by default the followin
 | `celery.concurrency` | The number of Celery concurrent child processes | `2` |
 | `celery.loglevel` | The loglevel of Celery | `WARNING` |
 | `persistence.media.enabled` | Enable persistence of media | `true` |
-| `persistence.media.enabledOnWorker` | Enable persistence of media on worker | `false` |
+| `persistence.media.enabledOnWorker` | Enable persistence of media on worker | `true` |
 | `persistence.media.size` | Specify the size of the media PVC | `1Gi` |
 | `persistence.media.existingClaim` | Name of an existing PVC to use | `null` |
 | `persistence.media.accessModes` | The accessModes of media | `{ ReadWriteOnce }` |

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -60,7 +60,7 @@ beat:
 persistence:
   media:
     enabled: true
-    enabledOnWorker: false
+    enabledOnWorker: true
     size: 1Gi
     existingClaim: null
     accessModes:


### PR DESCRIPTION
Due to the "send to external" functionality, the media volume is now required on the worker.