### PR TITLE
Add ability to enable Flower monitoring

### DIFF
--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backend
 description: The API for the Signals application
 type: application
-version: 4.7.1
+version: 4.8.0
 appVersion: 2.19.0
 
 dependencies:

--- a/charts/backend/README.md
+++ b/charts/backend/README.md
@@ -21,6 +21,7 @@ The backend Helm chart installs the Signalen API and the by default the followin
 | `uwsgi.threads` | The number of uWSGI threads | `2` |
 | `celery.concurrency` | The number of Celery concurrent child processes | `2` |
 | `celery.loglevel` | The loglevel of Celery | `WARNING` |
+| `flower.enabled` | Enable real-time Celery monitoring tool | `false` |
 | `persistence.media.enabled` | Enable persistence of media | `true` |
 | `persistence.media.enabledOnWorker` | Enable persistence of media on worker | `false` |
 | `persistence.media.size` | Specify the size of the media PVC | `1Gi` |

--- a/charts/backend/templates/_helpers.tpl
+++ b/charts/backend/templates/_helpers.tpl
@@ -78,3 +78,7 @@ Create the name of the service account to use
 {{- define "signals-backend.celery-beat" -}}
   {{- printf "%s-celery-beat" (include "signals-backend.fullname" .) -}}
 {{- end -}}
+
+{{- define "signals-backend.celery-flower" -}}
+  {{- printf "%s-celery-flower" (include "signals-backend.fullname" .) -}}
+{{- end -}}

--- a/charts/backend/templates/deployment-celery-flower.yaml
+++ b/charts/backend/templates/deployment-celery-flower.yaml
@@ -1,0 +1,91 @@
+{{- if .Values.flower.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "signals-backend.celery-flower" . }}
+  labels:
+    {{- include "signals-backend.labels" . | nindent 4 }}
+    component: cellery-flower
+spec:
+  replicas: {{ .Values.flowerReplicaCount }}
+  selector:
+    matchLabels:
+      {{- include "signals-backend.selectorLabels" . | nindent 6 }}
+      component: celery-flower
+  strategy:
+    type: {{ .Values.deploymentStrategy }}
+  template:
+    metadata:
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "signals-backend.labels" . | nindent 8 }}
+        component: celery-flower
+    spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: celery-flower
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/usr/local/bin/celery"]
+          args:
+            - '--app=signals'
+            - 'flower'
+            - '--address=0.0.0.0'
+            - '--port=8000'
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- with .Values.envVars }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ template "signals-backend.fullname" . }}
+            - secretRef:
+                name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "signals-backend.fullname" . }}{{ end }}
+          {{- with .Values.envFrom }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+          {{- toYaml .Values.flower.resources | nindent 12 }}
+          volumeMounts:
+            - name: media
+              mountPath: /app/media
+            - name: dwh-media
+              mountPath: /dwh_media
+          ports:
+            - name: http
+              protocol: TCP
+              containerPort: 8000
+{{- if ne (len .Values.extraVolumeMounts) 0 }}
+{{ toYaml .Values.extraVolumeMounts | indent 12 }}
+{{- end }}
+      volumes:
+        - name: media
+        {{- if and .Values.persistence.media.enabled .Values.persistence.media.enabledOnflower }}
+          persistentVolumeClaim:
+            claimName: {{ if .Values.persistence.media.existingClaim }}{{ .Values.persistence.media.existingClaim }}{{ else }}{{ template "signals-backend.fullname" . }}{{ end }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+        - name: dwh-media
+        {{- if and .Values.persistence.datawarehouse.enabled .Values.persistence.datawarehouse.enabledOnflower }}
+          persistentVolumeClaim:
+            claimName: {{ if .Values.persistence.datawarehouse.existingClaim }}{{ .Values.persistence.datawarehouse.existingClaim }}{{ else }}{{ template "signals-backend.fullname" . }}-datawarehouse{{ end }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+{{- if ne (len .Values.extraVolumes) 0 }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
+{{- end }}
+{{- end }}

--- a/charts/backend/templates/secret.yaml
+++ b/charts/backend/templates/secret.yaml
@@ -11,6 +11,7 @@ data:
   EMAIL_HOST_PASSWORD: {{ .Values.settings.email.password | b64enc | quote }}
   RABBITMQ_PASSWORD: {{ .Values.settings.rabbitmq.password | b64enc | quote }}
   SECRET_KEY: {{ .Values.settings.secretKey | b64enc | quote }}
+  FLOWER_BASIC_AUTH: {{ .Values.flower.basicAuth | b64enc | quote }}
   {{- if .Values.settings.sigmax.enabled }}
   SIGMAX_AUTH_TOKEN: {{ .Values.settings.sigmax.authToken | b64enc | quote }}
   {{- end }}

--- a/charts/backend/templates/service-flower.yaml
+++ b/charts/backend/templates/service-flower.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.flower.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,3 +16,4 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+{{- end }}

--- a/charts/backend/templates/service-flower.yaml
+++ b/charts/backend/templates/service-flower.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name:  {{ template "signals-backend.celery-flower" . }}
+  labels:
+    {{- include "signals-backend.labels" . | nindent 4 }}
+    component: cellery-flower
+spec:
+  selector:
+    {{- include "signals-backend.labels" . | nindent 4 }}
+    component: celery-flower
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -57,6 +57,11 @@ worker:
 beat:
   resources: {}
 
+flower:
+  enabled: false
+  basicAuth: signalen:signalen
+  resources: {}
+
 persistence:
   media:
     enabled: true

--- a/charts/classification/Chart.yaml
+++ b/charts/classification/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: classification
 description: Machine learning prediction API
 type: application
-version: 4.7.1
+version: 4.8.0
 appVersion: 47000c5f9b9a21aec846f3de53108d5df25acd28

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: frontend
 description: The web frontend for the Signals application
 type: application
-version: 4.7.1
+version: 4.8.0
 appVersion: 2.11.3


### PR DESCRIPTION
In addition of https://github.com/Amsterdam/signals/pull/1175 this adds support for monitoring Celery with Flower. With `flower.enabled` a new Pod is deployed that monitors the Celery task queue. 