### PR TITLE
Add tolerations and affinity settings

### DIFF
--- a/charts/backend/Chart.lock
+++ b/charts/backend/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.6.26
+  version: 11.9.13
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
-  version: 10.1.19
+  version: 12.0.3
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.17.3
-digest: sha256:93b3b9d04150d88aa2db924ac06a7b7286250ddb84b833fad234bd734c775b11
-generated: "2023-03-27T14:51:38.050495552+02:00"
+digest: sha256:ecef2ef2aef5c0b76daae2e5f64c1a5224e5cc303a809450715c44d5ca3c53fc
+generated: "2023-06-23T12:42:29.985526+02:00"

--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backend
 description: The API for the Signals application
 type: application
-version: 5.0.0
+version: 5.1.0
 appVersion: 2.19.0
 
 dependencies:

--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -7,12 +7,12 @@ appVersion: 2.19.0
 
 dependencies:
   - name: postgresql
-    version: ~11.6.0
+    version: ~11.9.0
     repository: https://charts.bitnami.com/bitnami
     tags:
       - postgresql
   - name: rabbitmq
-    version: ~10.1.0
+    version: ~12.0.0
     repository: https://charts.bitnami.com/bitnami
     tags:
       - rabbitmq

--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backend
 description: The API for the Signals application
 type: application
-version: 4.8.1
+version: 5.0.0
 appVersion: 2.19.0
 
 dependencies:

--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backend
 description: The API for the Signals application
 type: application
-version: 4.8.0
+version: 4.8.1
 appVersion: 2.19.0
 
 dependencies:

--- a/charts/backend/templates/deployment-celery-beat.yaml
+++ b/charts/backend/templates/deployment-celery-beat.yaml
@@ -24,6 +24,14 @@ spec:
     spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: celery-beat
           securityContext:

--- a/charts/backend/templates/deployment-celery-worker.yaml
+++ b/charts/backend/templates/deployment-celery-worker.yaml
@@ -27,6 +27,14 @@ spec:
     spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: celery-worker
           securityContext:

--- a/charts/backend/templates/deployment.yaml
+++ b/charts/backend/templates/deployment.yaml
@@ -27,6 +27,14 @@ spec:
     spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: migrate
           securityContext:

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -109,6 +109,10 @@ envVars: []
 #       name: config-map-name
 #       key: config-map-key
 
+tolerations: []
+
+affinity: {}
+
 settings:
   secretKey: "change-to-something-secret"
   allowedHosts: "*"

--- a/charts/classification/Chart.yaml
+++ b/charts/classification/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: classification
 description: Machine learning prediction API
 type: application
-version: 4.8.1
+version: 5.0.0
 appVersion: 47000c5f9b9a21aec846f3de53108d5df25acd28

--- a/charts/classification/Chart.yaml
+++ b/charts/classification/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: classification
 description: Machine learning prediction API
 type: application
-version: 4.8.0
+version: 4.8.1
 appVersion: 47000c5f9b9a21aec846f3de53108d5df25acd28

--- a/charts/classification/Chart.yaml
+++ b/charts/classification/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: classification
 description: Machine learning prediction API
 type: application
-version: 5.0.0
+version: 5.1.0
 appVersion: 47000c5f9b9a21aec846f3de53108d5df25acd28

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: frontend
 description: The web frontend for the Signals application
 type: application
-version: 4.8.1
+version: 5.0.0
 appVersion: 2.11.3

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: frontend
 description: The web frontend for the Signals application
 type: application
-version: 5.0.0
+version: 5.1.0
 appVersion: 2.11.3

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: frontend
 description: The web frontend for the Signals application
 type: application
-version: 4.8.0
+version: 4.8.1
 appVersion: 2.11.3

--- a/charts/frontend/templates/deployment.yaml
+++ b/charts/frontend/templates/deployment.yaml
@@ -50,6 +50,14 @@ spec:
             - name: config
               mountPath: /app.json
               subPath: "app.json"
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- if ne (len .Values.extraVolumeMounts) 0 }}
 {{ toYaml .Values.extraVolumeMounts | indent 12 }}
 {{- end }}

--- a/charts/frontend/values.yaml
+++ b/charts/frontend/values.yaml
@@ -37,3 +37,7 @@ config: {}
 
 extraVolumes: []
 extraVolumeMounts: []
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This allows configurating [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) and [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).

Depends on #57 