### PR TITLE
chore: bump Helm chart version to 4.9.0

### DIFF
--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backend
 description: The API for the Signals application
 type: application
-version: 4.8.0
+version: 4.9.0
 appVersion: 2.19.0
 
 dependencies:

--- a/charts/classification/Chart.yaml
+++ b/charts/classification/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: classification
 description: Machine learning prediction API
 type: application
-version: 4.8.0
+version: 4.9.0
 appVersion: 47000c5f9b9a21aec846f3de53108d5df25acd28

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: frontend
 description: The web frontend for the Signals application
 type: application
-version: 4.8.0
+version: 4.9.0
 appVersion: 2.11.3


### PR DESCRIPTION
This fixes the missing version bumps in #59 