### PR TITLE
Add hook to run backend management commands

### DIFF
--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: backend
 description: The API for the Signals application
 type: application
-version: 4.9.0
-appVersion: 2.19.0
+version: 4.10.0
+appVersion: 2.30.7
 
 dependencies:
   - name: postgresql

--- a/charts/backend/README.md
+++ b/charts/backend/README.md
@@ -40,6 +40,7 @@ The backend Helm chart installs the Signalen API and the by default the followin
 | `envFrom` | Additional environment variables mounted from [secrets](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables) or [config maps](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables). | `[]` |
 | `env` | Additional environment variables passed directly to containers. | `{}` |
 | `envVars` | Similar to env but with support for all possible configurations. | `[]` |
+| `managementCommands` | Run management commands post-install and post-upgrade | `""` |
 | `settings.secretKey` | The secret key of the backend | `change-to-something-secret` |
 | `settings.allowedHosts` | Restrict the allowed hosts of the API | `*` |
 | `settings.defaultPdokMunicipalities` | A (comma-seperated) list of [PDOK municipalities](https://www.pdok.nl/introductie/-/article/cbs-wijken-en-buurten) the API allows complaints for (e.g. `"Amsterdam,'s-Hertogenbosch"`) | `""` |

--- a/charts/backend/templates/job-management-commands.yaml
+++ b/charts/backend/templates/job-management-commands.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.managementCommands }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "signals-backend.fullname" . }}-management-commands
+  labels:
+    {{- include "signals-backend.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: api
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - sh
+            - "-c"
+            - |
+                /bin/bash <<'EOF'
+                {{ .Values.managementCommands | nindent 16 }}
+                EOF
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- with .Values.envVars }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ template "signals-backend.fullname" . }}
+            - secretRef:
+                name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "signals-backend.fullname" . }}{{ end }}
+          {{- with .Values.envFrom }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: media
+              mountPath: /app/media
+            - name: dwh-media
+              mountPath: /dwh_media
+{{- if ne (len .Values.extraVolumeMounts) 0 }}
+{{ toYaml .Values.extraVolumeMounts | indent 12 }}
+{{- end }}
+      volumes:
+        - name: media
+        {{- if .Values.persistence.media.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ if .Values.persistence.media.existingClaim }}{{ .Values.persistence.media.existingClaim }}{{ else }}{{ template "signals-backend.fullname" . }}{{ end }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+        - name: dwh-media
+        {{- if .Values.persistence.datawarehouse.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ if .Values.persistence.datawarehouse.existingClaim }}{{ .Values.persistence.datawarehouse.existingClaim }}{{ else }}{{ template "signals-backend.fullname" . }}-datawarehouse{{ end }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+{{- if ne (len .Values.extraVolumes) 0 }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
+{{- end }}
+{{- end }}

--- a/charts/backend/templates/job-management-commands.yaml
+++ b/charts/backend/templates/job-management-commands.yaml
@@ -27,10 +27,10 @@ spec:
           command:
             - sh
             - "-c"
+          args:
             - |
-                /bin/bash <<'EOF'
+                /bin/bash
                 {{ .Values.managementCommands | nindent 16 }}
-                EOF
           env:
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}

--- a/charts/backend/templates/job-management-commands.yaml
+++ b/charts/backend/templates/job-management-commands.yaml
@@ -25,11 +25,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
-            - sh
-            - "-c"
+            - /bin/bash
           args:
+            - "-c"
             - |
-                /bin/bash
                 {{ .Values.managementCommands | nindent 16 }}
           env:
             {{- range $key, $value := .Values.env }}

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -109,6 +109,12 @@ envVars: []
 #       name: config-map-name
 #       key: config-map-key
 
+# -- Hook to run one or multiple management commands post-install and post-upgrade.
+managementCommands: ""
+# managementCommands: |
+#   python manage.py elastic_index --init
+#   python manage.py elastic_index --index-all
+
 settings:
   secretKey: "change-to-something-secret"
   allowedHosts: "*"

--- a/charts/classification/Chart.yaml
+++ b/charts/classification/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: classification
 description: Machine learning prediction API
 type: application
-version: 4.9.0
+version: 4.10.0
 appVersion: 47000c5f9b9a21aec846f3de53108d5df25acd28

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: frontend
 description: The web frontend for the Signals application
 type: application
-version: 4.9.0
-appVersion: 2.11.3
+version: 4.10.0
+appVersion: 2.14.5


### PR DESCRIPTION
This PR adds the feature to run backend management commands post-install and post-upgrade. The hook can be configured with `managementCommands`:

```yaml
managementCommands: |
  python manage.py elastic_index --init
  python manage.py elastic_index --index-all
```

This feature can be used to run the Elasticsearch management commands post-install and post-upgrade, e.g. the management commands required for the new standard texts feature.