### PR TITLE
Clean up management commands job 600 seconds after completion

### DIFF
--- a/charts/backend/templates/job-management-commands.yaml
+++ b/charts/backend/templates/job-management-commands.yaml
@@ -9,6 +9,7 @@ metadata:
     helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-delete-policy: before-hook-creation
 spec:
+  ttlSecondsAfterFinished: 600
   template:
     metadata:
       name: "{{ .Release.Name }}"


### PR DESCRIPTION
This change makes sure the management commands job are cleaned up 600 seconds after completion. The change is required because Helm currently [does not clean up hook resources by itself](https://helm.sh/docs/topics/charts_hooks/#hook-resources-are-not-managed-with-corresponding-releases).

When the Job is not deleted, uninstalling the Helm chart also is not possible, because the corresponding pods block deleting the associated volume.

An alternative solution could be to add `hook-succeeded,hook-failed` to the [hook deletion policy](https://helm.sh/docs/topics/charts_hooks/#hook-deletion-policies), but this makes it difficult for operators to track if a Job was completed succesfully, as the Job will be deleted immediately after success or failure.