### PR TITLE
adding configurable probes for backend

### DIFF
--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backend
 description: The API for the Signals application
 type: application
-version: 4.13.1
+version: 4.13.2
 appVersion: 2.34.1
 
 dependencies:

--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: backend
 description: The API for the Signals application
 type: application
-version: 4.12.0
-appVersion: 2.33.0
+version: 4.13.0
+appVersion: 2.34.1
 
 dependencies:
   - name: postgresql

--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backend
 description: The API for the Signals application
 type: application
-version: 4.13.0
+version: 4.13.1
 appVersion: 2.34.1
 
 dependencies:

--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backend
 description: The API for the Signals application
 type: application
-version: 4.13.2
+version: 4.13.3
 appVersion: 2.34.1
 
 dependencies:

--- a/charts/backend/templates/deployment.yaml
+++ b/charts/backend/templates/deployment.yaml
@@ -102,6 +102,7 @@ spec:
 {{ toYaml .Values.extraVolumeMounts | indent 12 }}
 {{- end }}
 
+{{ if .Values.probes.backend }}
           livenessProbe:
             httpGet:
               path: /status/health
@@ -116,6 +117,22 @@ spec:
             initialDelaySeconds: {{ if .Values.probes.backend.readinessProbe.initialDelaySeconds }}{{ .Values.probes.backend.readinessProbe.initialDelaySeconds }}{{ else }}1{{ end}}
             periodSeconds: {{ if .Values.probes.backend.readinessProbe.initialDelaySeconds }}{{ .Values.probes.backend.readinessProbe.initialDelaySeconds }}{{ else }}10{{ end }}
             timeoutSeconds: {{ if .Values.probes.backend.readinessProbe.timeoutSeconds }}{{ .Values.probes.backend.readinessProbe.timeoutSeconds }}{{ else }}1{{ end }}
+{{ else }}
+          livenessProbe:
+            httpGet:
+              path: /status/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /status/health
+              port: http
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 1
+{{ end }}
           ports:
             - name: http
               protocol: TCP

--- a/charts/backend/templates/deployment.yaml
+++ b/charts/backend/templates/deployment.yaml
@@ -107,9 +107,9 @@ spec:
             httpGet:
               path: /status/health
               port: http
-            initialDelaySeconds: {{ if .Values.probes.backend.livenessProbe.initialDelaySeconds }}{{ .Values.probes.backend.livenessProbes.initialDelaySeconds }}{{ else }}30{{ end }}
-            periodSeconds: {{ if .Values.probes.backend.livenessProbe.periodSeconds }}{{ .Values.probes.backend.livenessProbes.periodSeconds }}{{ else }}10{{ end }}
-            timeoutSeconds: {{ if .Values.probes.backend.livenessProbe.timeoutSeconds }}{{ .Values.probes.backend.livenessProbes.timeoutSeconds }}{{ else }}1{{ end }}
+            initialDelaySeconds: {{ if .Values.probes.backend.livenessProbe.initialDelaySeconds }}{{ .Values.probes.backend.livenessProbe.initialDelaySeconds }}{{ else }}30{{ end }}
+            periodSeconds: {{ if .Values.probes.backend.livenessProbe.periodSeconds }}{{ .Values.probes.backend.livenessProbe.periodSeconds }}{{ else }}10{{ end }}
+            timeoutSeconds: {{ if .Values.probes.backend.livenessProbe.timeoutSeconds }}{{ .Values.probes.backend.livenessProbe.timeoutSeconds }}{{ else }}1{{ end }}
           readinessProbe:
             httpGet:
               path: /status/health

--- a/charts/backend/templates/deployment.yaml
+++ b/charts/backend/templates/deployment.yaml
@@ -102,7 +102,6 @@ spec:
 {{ toYaml .Values.extraVolumeMounts | indent 12 }}
 {{- end }}
 
-{{ if .Values.probes.backend }}
           livenessProbe:
             httpGet:
               path: /status/health
@@ -117,22 +116,6 @@ spec:
             initialDelaySeconds: {{ if .Values.probes.backend.readinessProbe.initialDelaySeconds }}{{ .Values.probes.backend.readinessProbe.initialDelaySeconds }}{{ else }}1{{ end}}
             periodSeconds: {{ if .Values.probes.backend.readinessProbe.initialDelaySeconds }}{{ .Values.probes.backend.readinessProbe.periodSeconds }}{{ else }}10{{ end }}
             timeoutSeconds: {{ if .Values.probes.backend.readinessProbe.timeoutSeconds }}{{ .Values.probes.backend.readinessProbe.timeoutSeconds }}{{ else }}1{{ end }}
-{{ else }}
-          livenessProbe:
-            httpGet:
-              path: /status/health
-              port: http
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            timeoutSeconds: 1
-          readinessProbe:
-            httpGet:
-              path: /status/health
-              port: http
-            initialDelaySeconds: 1
-            periodSeconds: 10
-            timeoutSeconds: 1
-{{ end }}
           ports:
             - name: http
               protocol: TCP

--- a/charts/backend/templates/deployment.yaml
+++ b/charts/backend/templates/deployment.yaml
@@ -107,15 +107,15 @@ spec:
               path: /status/health
               port: http
             initialDelaySeconds: {{ .Values.probes.backend.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ if .Values.probes.backend.livenessProbe.periodSeconds }}{{ .Values.probes.backend.livenessProbe.periodSeconds }}{{ else }}10{{ end }}
-            timeoutSeconds: {{ if .Values.probes.backend.livenessProbe.timeoutSeconds }}{{ .Values.probes.backend.livenessProbe.timeoutSeconds }}{{ else }}1{{ end }}
+            periodSeconds: {{ .Values.probes.backend.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.backend.livenessProbe.timeoutSeconds }}
           readinessProbe:
             httpGet:
               path: /status/health
               port: http
-            initialDelaySeconds: {{ if .Values.probes.backend.readinessProbe.initialDelaySeconds }}{{ .Values.probes.backend.readinessProbe.initialDelaySeconds }}{{ else }}1{{ end}}
-            periodSeconds: {{ if .Values.probes.backend.readinessProbe.initialDelaySeconds }}{{ .Values.probes.backend.readinessProbe.periodSeconds }}{{ else }}10{{ end }}
-            timeoutSeconds: {{ if .Values.probes.backend.readinessProbe.timeoutSeconds }}{{ .Values.probes.backend.readinessProbe.timeoutSeconds }}{{ else }}1{{ end }}
+            initialDelaySeconds: {{ .Values.probes.backend.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.backend.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.backend.readinessProbe.timeoutSeconds }}
           ports:
             - name: http
               protocol: TCP

--- a/charts/backend/templates/deployment.yaml
+++ b/charts/backend/templates/deployment.yaml
@@ -101,18 +101,21 @@ spec:
 {{- if ne (len .Values.extraVolumeMounts) 0 }}
 {{ toYaml .Values.extraVolumeMounts | indent 12 }}
 {{- end }}
+
           livenessProbe:
             httpGet:
               path: /status/health
               port: http
-            initialDelaySeconds: 30
-            periodSeconds: 10
+            initialDelaySeconds: {{ if .Values.probes.backend.livenessProbes.initialDelaySeconds }}{{ .Values.probes.backend.livenessProbes.initialDelaySeconds }}{{ else }}30{{ end }}
+            periodSeconds: {{ if .Values.probes.backend.livenessProbes.periodSeconds }}{{ .Values.probes.backend.livenessProbes.periodSeconds }}{{ else }}10{{ end }}
+            timeoutSeconds: {{ if .Values.probes.backend.livenessProbes.timeoutSeconds }}{{ .Values.probes.backend.livenessProbes.timeoutSeconds }}{{ else }}1{{ end }}
           readinessProbe:
             httpGet:
               path: /status/health
               port: http
-            initialDelaySeconds: 1
-            periodSeconds: 10
+            initialDelaySeconds: {{ if .Values.probes.backend.readinessProbe.initialDelaySeconds }}{{ .Values.probes.backend.readinessProbe.initialDelaySeconds }}{{ else }}1{{ end}}
+            periodSeconds: {{ if .Values.probes.backend.readinessProbe.initialDelaySeconds }}{{ .Values.probes.backend.readinessProbe.initialDelaySeconds }}{{ else }}10{{ end }}
+            timeoutSeconds: {{ if .Values.probes.backend.readinessProbe.timeoutSeconds }}{{ .Values.probes.backend.readinessProbe.timeoutSeconds }}{{ else }}1{{ end }}
           ports:
             - name: http
               protocol: TCP

--- a/charts/backend/templates/deployment.yaml
+++ b/charts/backend/templates/deployment.yaml
@@ -115,7 +115,7 @@ spec:
               path: /status/health
               port: http
             initialDelaySeconds: {{ if .Values.probes.backend.readinessProbe.initialDelaySeconds }}{{ .Values.probes.backend.readinessProbe.initialDelaySeconds }}{{ else }}1{{ end}}
-            periodSeconds: {{ if .Values.probes.backend.readinessProbe.initialDelaySeconds }}{{ .Values.probes.backend.readinessProbe.initialDelaySeconds }}{{ else }}10{{ end }}
+            periodSeconds: {{ if .Values.probes.backend.readinessProbe.initialDelaySeconds }}{{ .Values.probes.backend.readinessProbe.periodSeconds }}{{ else }}10{{ end }}
             timeoutSeconds: {{ if .Values.probes.backend.readinessProbe.timeoutSeconds }}{{ .Values.probes.backend.readinessProbe.timeoutSeconds }}{{ else }}1{{ end }}
 {{ else }}
           livenessProbe:

--- a/charts/backend/templates/deployment.yaml
+++ b/charts/backend/templates/deployment.yaml
@@ -56,6 +56,34 @@ spec:
           {{- end }}
           resources:
           {{- toYaml .Values.resources | nindent 12 }}
+        - name: create-cache-table
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /usr/local/bin/python
+          args:
+            - '/app/manage.py'
+            - 'createcachetable'
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- with .Values.envVars }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ template "signals-backend.fullname" . }}
+            - secretRef:
+                name: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "signals-backend.fullname" . }}{{ end }}
+          {{- with .Values.envFrom }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+          {{- toYaml .Values.resources | nindent 12 }}
       containers:
         - name: api
           securityContext:

--- a/charts/backend/templates/deployment.yaml
+++ b/charts/backend/templates/deployment.yaml
@@ -107,7 +107,7 @@ spec:
             httpGet:
               path: /status/health
               port: http
-            initialDelaySeconds: {{ if .Values.probes.backend.livenessProbe.initialDelaySeconds }}{{ .Values.probes.backend.livenessProbe.initialDelaySeconds }}{{ else }}30{{ end }}
+            initialDelaySeconds: {{ .Values.probes.backend.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ if .Values.probes.backend.livenessProbe.periodSeconds }}{{ .Values.probes.backend.livenessProbe.periodSeconds }}{{ else }}10{{ end }}
             timeoutSeconds: {{ if .Values.probes.backend.livenessProbe.timeoutSeconds }}{{ .Values.probes.backend.livenessProbe.timeoutSeconds }}{{ else }}1{{ end }}
           readinessProbe:

--- a/charts/backend/templates/deployment.yaml
+++ b/charts/backend/templates/deployment.yaml
@@ -107,9 +107,9 @@ spec:
             httpGet:
               path: /status/health
               port: http
-            initialDelaySeconds: {{ if .Values.probes.backend.livenessProbes.initialDelaySeconds }}{{ .Values.probes.backend.livenessProbes.initialDelaySeconds }}{{ else }}30{{ end }}
-            periodSeconds: {{ if .Values.probes.backend.livenessProbes.periodSeconds }}{{ .Values.probes.backend.livenessProbes.periodSeconds }}{{ else }}10{{ end }}
-            timeoutSeconds: {{ if .Values.probes.backend.livenessProbes.timeoutSeconds }}{{ .Values.probes.backend.livenessProbes.timeoutSeconds }}{{ else }}1{{ end }}
+            initialDelaySeconds: {{ if .Values.probes.backend.livenessProbe.initialDelaySeconds }}{{ .Values.probes.backend.livenessProbes.initialDelaySeconds }}{{ else }}30{{ end }}
+            periodSeconds: {{ if .Values.probes.backend.livenessProbe.periodSeconds }}{{ .Values.probes.backend.livenessProbes.periodSeconds }}{{ else }}10{{ end }}
+            timeoutSeconds: {{ if .Values.probes.backend.livenessProbe.timeoutSeconds }}{{ .Values.probes.backend.livenessProbes.timeoutSeconds }}{{ else }}1{{ end }}
           readinessProbe:
             httpGet:
               path: /status/health

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -49,6 +49,17 @@ ingress:
       hosts:
         - api.signals.local
 
+probes:
+  backend:
+    livenessProbes:
+      initialDelaySeconds: 30
+      periodSeconds: 15
+      timeoutSeconds: 15
+    readinessProbe:
+      initialDelaySeconds: 30
+      periodSeconds: 15
+      timeoutSeconds: 15
+
 resources: {}
 
 worker:

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -51,7 +51,7 @@ ingress:
 
 probes:
   backend:
-    livenessProbes:
+    livenessProbe:
       initialDelaySeconds: 30
       periodSeconds: 15
       timeoutSeconds: 15

--- a/charts/classification/Chart.yaml
+++ b/charts/classification/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: classification
 description: Machine learning prediction API
 type: application
-version: 4.13.0
+version: 4.13.1
 appVersion: ad60447d1733473e30ab0a3ba53d58141cc1d250

--- a/charts/classification/Chart.yaml
+++ b/charts/classification/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: classification
 description: Machine learning prediction API
 type: application
-version: 4.13.1
+version: 4.13.2
 appVersion: ad60447d1733473e30ab0a3ba53d58141cc1d250

--- a/charts/classification/Chart.yaml
+++ b/charts/classification/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: classification
 description: Machine learning prediction API
 type: application
-version: 4.12.0
+version: 4.13.0
 appVersion: ad60447d1733473e30ab0a3ba53d58141cc1d250

--- a/charts/classification/Chart.yaml
+++ b/charts/classification/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: classification
 description: Machine learning prediction API
 type: application
-version: 4.13.2
+version: 4.13.3
 appVersion: ad60447d1733473e30ab0a3ba53d58141cc1d250

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: frontend
 description: The web frontend for the Signals application
 type: application
-version: 4.12.0
-appVersion: 2.14.19
+version: 4.13.0
+appVersion: 2.14.21

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: frontend
 description: The web frontend for the Signals application
 type: application
-version: 4.13.0
+version: 4.13.1
 appVersion: 2.14.21

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: frontend
 description: The web frontend for the Signals application
 type: application
-version: 4.13.1
-appVersion: 2.14.21
+version: 4.13.2
+appVersion: 2.14.22

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: frontend
 description: The web frontend for the Signals application
 type: application
-version: 4.13.2
+version: 4.13.3
 appVersion: 2.14.22


### PR DESCRIPTION
The default probe values need to be changed in order to improve the robustness of our backend service.
We added a structure in values.yaml to make it configurable with defaults that represent the current settings.

The helm lint tools seems to be happy about our changes;
==> Linting charts/backend
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
