### PR TITLE
Use selectorLabels instead of labels for service selector

### DIFF
--- a/charts/backend/templates/service.yaml
+++ b/charts/backend/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "signals-backend.labels" . | nindent 4 }}
 spec:
   selector:
-    {{- include "signals-backend.labels" . | nindent 4 }}
+    {{- include "signals-backend.selectorLabels" . | nindent 4 }}
     component: backend
   type: {{ .Values.service.type }}
   ports:

--- a/charts/frontend/templates/service.yaml
+++ b/charts/frontend/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "signals-frontend.labels" . | nindent 4 }}
 spec:
   selector:
-    {{- include "signals-frontend.labels" . | nindent 4 }}
+    {{- include "signals-frontend.selectorLabels" . | nindent 4 }}
   type: {{ .Values.service.type }}
   ports:
     - name: http


### PR DESCRIPTION
This fix makes sure the service uses `selectorLabels` instead of `labels`.

Currently every Helm chart upgrade for backend and frontend results in a (temporary) breaking service, because the service is hardcoded to a specific version of the deployment in `labels`. So rolling upgrades are currently not working.