### PR TITLE
Switch to Bitnami legacy for subcharts

### DIFF
--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backend
 description: The API for the Signals application
 type: application
-version: 4.20.2
+version: 4.20.3
 appVersion: 2.43.8
 
 dependencies:

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -213,6 +213,9 @@ settings:
 ## PostgreSQL subchart ##
 #########################
 postgresql:
+  image:
+    repository: bitnamilegacy/postgresql
+
   auth:
     postgresPassword: signalen
     database: signalen
@@ -227,6 +230,9 @@ postgresql:
 ## RabbitMQ subchart ##
 #######################
 rabbitmq:
+  image:
+    repository: bitnamilegacy/rabbitmq
+
   auth:
     username: signalen
     password: signalen

--- a/charts/classification/Chart.yaml
+++ b/charts/classification/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: classification
 description: Machine learning prediction API
 type: application
-version: 4.20.2
+version: 4.20.3
 appVersion: ad60447d1733473e30ab0a3ba53d58141cc1d250

--- a/charts/frontend/Chart.yaml
+++ b/charts/frontend/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: frontend
 description: The web frontend for the Signals application
 type: application
-version: 4.20.2
+version: 4.20.3
 appVersion: 2.27.0


### PR DESCRIPTION
This changes the default repository of the subcharts to bitnamilegacy, as bitnami is phased out starting August 28th:
https://github.com/bitnami/charts/issues/35164

For the long term we should consider upgrading to other open source Helm charts or operators.